### PR TITLE
Path.test.s 

### DIFF
--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -2173,6 +2173,68 @@ function isTrailed( test )
 
 //
 
+function isGlob( test )
+{
+
+  test.case = 'this is not glob';
+
+  test.is( !_.path.isGlob( '!a.js' ) );
+  test.is( !_.path.isGlob( '^a.js' ) );
+  test.is( !_.path.isGlob( '+a.js' ) );
+  test.is( !_.path.isGlob( '!' ) );
+  test.is( !_.path.isGlob( '^' ) );
+  test.is( !_.path.isGlob( '+' ) );
+
+  /**/
+
+  test.case = 'this is glob';
+
+  test.is( _.path.isGlob( '?' ) );
+  test.is( _.path.isGlob( '*' ) );
+  test.is( _.path.isGlob( '**' ) );
+
+  test.is( _.path.isGlob( '?c.js' ) );
+  test.is( _.path.isGlob( '*.js' ) );
+  test.is( _.path.isGlob( '**/a.js' ) );
+
+  test.is( _.path.isGlob( 'dir?c/a.js' ) );
+  test.is( _.path.isGlob( 'dir/*.js' ) );
+  test.is( _.path.isGlob( 'dir/**.js' ) );
+  test.is( _.path.isGlob( 'dir/**/a.js' ) );
+
+  test.is( _.path.isGlob( '/dir?c/a.js' ) );
+  test.is( _.path.isGlob( '/dir/*.js' ) );
+  test.is( _.path.isGlob( '/dir/**.js' ) );
+  test.is( _.path.isGlob( '/dir/**/a.js' ) );
+
+  test.is( _.path.isGlob( '[a-c]' ) );
+  test.is( _.path.isGlob( '{a,c}' ) );
+  test.is( _.path.isGlob( '(a|b)' ) );
+
+  test.is( _.path.isGlob( '(ab)' ) );
+  test.is( _.path.isGlob( '@(ab)' ) );
+  test.is( _.path.isGlob( '!(ab)' ) );
+  test.is( _.path.isGlob( '?(ab)' ) );
+  test.is( _.path.isGlob( '*(ab)' ) );
+  test.is( _.path.isGlob( '+(ab)' ) );
+
+  test.is( _.path.isGlob( 'dir/[a-c].js' ) );
+  test.is( _.path.isGlob( 'dir/{a,c}.js' ) );
+  test.is( _.path.isGlob( 'dir/(a|b).js' ) );
+
+  test.is( _.path.isGlob( 'dir/(ab).js' ) );
+  test.is( _.path.isGlob( 'dir/@(ab).js' ) );
+  test.is( _.path.isGlob( 'dir/!(ab).js' ) );
+  test.is( _.path.isGlob( 'dir/?(ab).js' ) );
+  test.is( _.path.isGlob( 'dir/*(ab).js' ) );
+  test.is( _.path.isGlob( 'dir/+(ab).js' ) );
+
+  test.is( _.path.isGlob( '/index/**' ) );
+
+}
+
+//
+
 function begins( test )
 {
 
@@ -5161,6 +5223,7 @@ var Self =
     isRoot,
     isDotted,
     isTrailed,
+    isGlob,
 
     begins,
     ends,

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -2190,6 +2190,8 @@ function begins( test )
   var got = _.path.begins( 3, 3 );
   test.identical( got, true );
 
+  //
+
   test.case = 'Same string';
 
   var got = _.path.begins( 'a', 'a' );
@@ -2232,7 +2234,7 @@ function begins( test )
 
   var got = _.path.begins( 'foo/bar//baz/asdf/quux/..//.', 'foo' );
   test.identical( got, true );
-  
+
   var got = _.path.begins( 'foo/bar//baz/asdf/quux/..//.', 'foo/' );
   test.identical( got, true );
 
@@ -2312,7 +2314,76 @@ function begins( test )
 function ends( test )
 {
 
+  test.case = 'Doesn´t End';
+
+  var got = _.path.ends( 'a/b', 'a' );
+  test.identical( got, false );
+
+  var got = _.path.ends( 'a/b', '/b' );
+  test.identical( got, false );
+
+  var got = _.path.ends( 'this/is/some/path', '/some/path' );
+  test.identical( got, false );
+
+  var got = _.path.ends( '/this/is/some/path', '/some/path' );
+  test.identical( got, false );
+
+  var got = _.path.ends( 'this/is/some/path', 'this/is' );
+  test.identical( got, false );
+
+  var got = _.path.ends( 'this/is/some/pathpath', 'path' );
+  test.identical( got, false );
+
+  var got = _.path.ends( 'this/is/some/path', '/this/is/some/path' );
+  test.identical( got, false );
+
+  var got = _.path.ends( '.src/a1', '.a1' );
+  test.identical( got, false );
+
+  var got = _.path.ends( '.src/a1', '/a1' );
+  test.identical( got, false );
+
+  var got = _.path.ends( 'c:/src/a1', '/src/a1' );
+  test.identical( got, false );
+
+  var got = _.path.ends( 'c:/src/_a1', 'a1' );
+  test.identical( got, false );
+
+  var got = _.path.ends( 'foo/bar//baz/asdf/quux/..//.', 'quux' );
+  test.identical( got, false );
+
+  var got = _.path.ends( 'foo/bar//baz/asdf/quux/..', 'asdf' );
+  test.identical( got, false );
+
+  var got = _.path.ends( 'foo/bar//baz/asdf/quux/..', '/..' );
+  test.identical( got, false );
+
+  //
+
+  test.case = 'Ends';
+
+  var got = _.path.ends( 'a', 'a' );
+  test.identical( got, true );
+
+  var got = _.path.ends( '/a', './a' );
+  test.identical( got, true );
+
+  var got = _.path.ends( '.a', 'a' );
+  test.identical( got, true );
+
+  var got = _.path.ends( '/C://src/a1/', 'a1/' );
+  test.identical( got, true );
+
+  var got = _.path.ends( 'this/is/some/path', 'path' );
+  test.identical( got, true );
+
+  var got = _.path.ends( 'this/is/some/path', './path' );
+  test.identical( got, true );
+
   var got = _.path.ends( 'this/is/some/path', 'some/path' );
+  test.identical( got, true );
+
+  var got = _.path.ends( 'this/is/some/path', 'is/some/path' );
   test.identical( got, true );
 
   var got = _.path.ends( 'this/is/some/path', 'this/is/some/path' );
@@ -2321,23 +2392,80 @@ function ends( test )
   var got = _.path.ends( '/this/is/some/path', 'some/path' );
   test.identical( got, true );
 
-  var got = _.path.ends( '/this/is/some/path', 'this/is/some/path' );
+  var got = _.path.ends( '/this/is/some/path', './some/path' );
   test.identical( got, true );
 
-  var got = _.path.ends( 'this/is/some/path', '/some/path' );
-  test.identical( got, false );
-
-  var got = _.path.ends( 'this/is/some/path', '/this/is/some/path' );
-  test.identical( got, false );
-
-  var got = _.path.ends( '/this/is/some/path', '/some/path' );
-  test.identical( got, false );
+  var got = _.path.ends( '/this/is/some/path', 'this/is/some/path' );
+  test.identical( got, true );
 
   var got = _.path.ends( '/this/is/some/path', '/this/is/some/path' );
   test.identical( got, true );
 
-  var got = _.path.ends( 'this/is/some/pathpath', 'path' );
-  test.identical( got, false );
+  var got = _.path.ends( 'c:/file.src_a1', 'src_a1' );
+  test.identical( got, true );
+
+  var got = _.path.ends( 'c:/file/src/_a1', '_a1' );
+  test.identical( got, true );
+
+  var got = _.path.ends( 'c:/file/src._a1', '_a1' );
+  test.identical( got, true );
+
+  var got = _.path.ends( 'foo/bar//baz/asdf/quux/..//.', './/.' );
+  test.identical( got, true );
+
+  var got = _.path.ends( 'foo/bar//baz/asdf/quux/..//.', '/.' );
+  test.identical( got, true );
+
+  var got = _.path.ends( 'foo/bar//baz/asdf/quux/..//.', '.' );
+  test.identical( got, true );
+
+  var got = _.path.ends( 'foo/bar//baz/asdf/quux/...', '.' );
+  test.identical( got, true );
+
+  /* */
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'No arguments';
+  test.shouldThrowError( () => _.path.ends( ) );
+
+  test.case = 'One argument';
+  test.shouldThrowError( () => _.path.ends( 'a' ) );
+
+//  test.case = 'Three arguments';
+//  test.shouldThrowError( () => _.path.ends( 'a', 'b', 'c' ) );
+
+  // Input is not path
+
+  test.case = 'No path - regexp';
+  test.shouldThrowError( () => _.path.ends( /foo/,  /foo/ ) );
+
+  test.case = 'No path - array';
+  test.shouldThrowError( () => _.path.ends( [ ], [ ] ) );
+
+  test.case = 'No path - object';
+  test.shouldThrowError( () => _.path.ends( { Path : 'C:/' }, { Path : 'C:/' } ) );
+
+  test.case = 'No path - undefined';
+  test.shouldThrowError( () => _.path.ends( undefined ) );
+
+  test.case = 'No path - undefined';
+  test.shouldThrowError( () => _.path.ends( undefined, undefined ) );
+
+  test.case = 'No path - null';
+  test.shouldThrowError( () => _.path.ends( null ) );
+
+  test.case = 'No path - null';
+  test.shouldThrowError( () => _.path.ends( null, null ) );
+
+  test.case = 'No path - NaN';
+  test.shouldThrowError( () => _.path.ends( NaN ) );
+
+  test.case = 'No path - NaN';
+  test.shouldThrowError( () => _.path.ends( NaN, NaN ) );
+
+
 
 }
 

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -885,33 +885,33 @@ function isNormalized( test )
   return;
 
   test.case = 'No arguments';
-  test.shouldThrowError( () => _.path.normalize( ) );
+  test.shouldThrowError( () => _.path.isNormalized( ) );
 
   test.case = 'Two arguments';
-  test.shouldThrowError( () => _.path.normalize( 'a', 'b' ) );
+  test.shouldThrowError( () => _.path.isNormalized( 'a', 'b' ) );
 
   // Input is not path
 
   test.case = 'No path - regexp';
-  test.shouldThrowError( () => _.path.normalize( /foo/ ) );
+  test.shouldThrowError( () => _.path.isNormalized( /foo/ ) );
 
   test.case = 'No path - number';
-  test.shouldThrowError( () => _.path.normalize( 3 ) );
+  test.shouldThrowError( () => _.path.isNormalized( 3 ) );
 
   test.case = 'No path - array';
-  test.shouldThrowError( () => _.path.normalize( [ '/C/', 'work/f' ] ) );
+  test.shouldThrowError( () => _.path.isNormalized( [ '/C/', 'work/f' ] ) );
 
   test.case = 'No path - object';
-  test.shouldThrowError( () => _.path.normalize( { Path : 'C:/foo/baz/bar' } ) );
+  test.shouldThrowError( () => _.path.isNormalized( { Path : 'C:/foo/baz/bar' } ) );
 
   test.case = 'No path - undefined';
-  test.shouldThrowError( () => _.path.normalize( undefined ) );
+  test.shouldThrowError( () => _.path.isNormalized( undefined ) );
 
   test.case = 'No path - null';
-  test.shouldThrowError( () => _.path.normalize( null ) );
+  test.shouldThrowError( () => _.path.isNormalized( null ) );
 
   test.case = 'No path - NaN';
-  test.shouldThrowError( () => _.path.normalize( NaN ) );
+  test.shouldThrowError( () => _.path.isNormalized( NaN ) );
 
 }
 
@@ -1283,6 +1283,41 @@ function isRefined( test )
   var expected = true;
   var got = _.path.isRefined( refined );
   test.identical( got, expected );
+
+  /* */
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'No arguments';
+  test.shouldThrowError( () => _.path.isRefined( ) );
+
+  test.case = 'Two arguments';
+  test.shouldThrowError( () => _.path.isRefined( 'a', 'b' ) );
+
+  // Input is not path
+
+  test.case = 'No path - regexp';
+  test.shouldThrowError( () => _.path.isRefined( /foo/ ) );
+
+  test.case = 'No path - number';
+  test.shouldThrowError( () => _.path.isRefined( 3 ) );
+
+  test.case = 'No path - array';
+  test.shouldThrowError( () => _.path.isRefined( [ '/C/', 'work/f' ] ) );
+
+  test.case = 'No path - object';
+  test.shouldThrowError( () => _.path.isRefined( { Path : 'C:/foo/baz/bar' } ) );
+
+  test.case = 'No path - undefined';
+  test.shouldThrowError( () => _.path.isRefined( undefined ) );
+
+  test.case = 'No path - null';
+  test.shouldThrowError( () => _.path.isRefined( null ) );
+
+  test.case = 'No path - NaN';
+  test.shouldThrowError( () => _.path.isRefined( NaN ) );
+
 }
 
 //

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -2048,6 +2048,131 @@ function isDotted( test )
 
 //
 
+function isTrailed( test )
+{
+
+  test.case = 'Is trailed';
+
+  var path = './';
+  var got = _.path.isTrailed( path );
+  test.identical( got, true );
+
+  var path = '.././';
+  var got = _.path.isTrailed( path );
+  test.identical( got, true );
+
+  var path = '/../';
+  var got = _.path.isTrailed( path );
+  test.identical( got, true );
+
+  var path = '/c/';
+  var got = _.path.isTrailed( path );
+  test.identical( got, true );
+
+  var path = 'src/a1/';
+  var got = _.path.isTrailed( path );
+  test.identical( got, true );
+
+  var path = 'c:/src/a1/';
+  var got = _.path.isTrailed( path );
+  test.identical( got, true );
+
+  var path = '/C://src/a1/';
+  var got = _.path.isTrailed( path );
+  test.identical( got, true );
+
+  var path = 'foo/bar//baz/asdf/quux/..//./';
+  var got = _.path.isTrailed( path );
+  test.identical( got, true );
+
+  test.case = 'Is not trailed';
+
+  var path = '';
+  var got = _.path.isTrailed( path );
+  test.identical( got, false );
+
+  var path = '/';
+  var got = _.path.isTrailed( path );
+  test.identical( got, false );
+
+  var path = '.';
+  var got = _.path.isTrailed( path );
+  test.identical( got, false );
+
+  var path = '/.';
+  var got = _.path.isTrailed( path );
+  test.identical( got, false );
+
+  var path = './.';
+  var got = _.path.isTrailed( path );
+  test.identical( got, false );
+
+  var path = '././..';
+  var got = _.path.isTrailed( path );
+  test.identical( got, false );
+
+  var path = './x/..';
+  var got = _.path.isTrailed( path );
+  test.identical( got, false );
+
+  var path = './c';
+  var got = _.path.isTrailed( path );
+  test.identical( got, false );
+
+  var path = '.src/a1';
+  var got = _.path.isTrailed( path );
+  test.identical( got, false );
+
+  var path = '.c:/src/a1';
+  var got = _.path.isTrailed( path );
+  test.identical( got, false );
+
+  var path = './C://src/a1';
+  var got = _.path.isTrailed( path );
+  test.identical( got, false );
+
+  var path = '.foo/bar//baz/asdf/quux/..//.';
+  var got = _.path.isTrailed( path );
+  test.identical( got, false );
+
+  /* */
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'No arguments';
+  test.shouldThrowError( () => _.path.isTrailed( ) );
+
+//  test.case = 'Two arguments';
+//  test.shouldThrowError( () => _.path.isTrailed( 'a', 'b' ) );
+
+  // Input is not path
+
+  test.case = 'No path - regexp';
+  test.shouldThrowError( () => _.path.isTrailed( /foo/ ) );
+
+  test.case = 'No path - number';
+  test.shouldThrowError( () => _.path.isTrailed( 3 ) );
+
+  test.case = 'No path - array';
+  test.shouldThrowError( () => _.path.isTrailed( [ '/C/', 'work/f' ] ) );
+
+  test.case = 'No path - object';
+  test.shouldThrowError( () => _.path.isTrailed( { Path : 'C:/foo/baz/bar' } ) );
+
+  test.case = 'No path - undefined';
+  test.shouldThrowError( () => _.path.isTrailed( undefined ) );
+
+  test.case = 'No path - null';
+  test.shouldThrowError( () => _.path.isTrailed( null ) );
+
+  test.case = 'No path - NaN';
+  test.shouldThrowError( () => _.path.isTrailed( NaN ) );
+
+}
+
+//
+
 function begins( test )
 {
 
@@ -4818,6 +4943,7 @@ var Self =
     isGlobal,
     isRoot,
     isDotted,
+    isTrailed,
 
     begins,
     ends,

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -2176,11 +2176,73 @@ function isTrailed( test )
 function begins( test )
 {
 
-  var got = _.path.begins( 'this/is/some/path', 'this/is' );
+  // qqq - should fail?
+
+  var got = _.path.begins(  );
+  test.identical( got, true );
+
+  var got = _.path.begins( undefined );
+  test.identical( got, true );
+
+  var got = _.path.begins( null, null );
+  test.identical( got, true );
+
+  var got = _.path.begins( 3, 3 );
+  test.identical( got, true );
+
+  test.case = 'Same string';
+
+  var got = _.path.begins( 'a', 'a' );
+  test.identical( got, true );
+
+  var got = _.path.begins( 'c:/', 'c:/' );
   test.identical( got, true );
 
   var got = _.path.begins( 'this/is/some/path', 'this/is/some/path' );
   test.identical( got, true );
+
+  var got = _.path.begins( '/this/is/some/path', '/this/is/some/path' );
+  test.identical( got, true );
+
+  test.case = 'Begins';
+
+  var got = _.path.begins( 'a/', 'a' );
+  test.identical( got, true );
+
+  var got = _.path.begins( 'a/b', 'a' );
+  test.identical( got, true );
+
+  var got = _.path.begins( 'this/is/some/path', 'this/is' );
+  test.identical( got, true );
+
+  var got = _.path.begins( '/this/is/some/path', '/this/is' );
+  test.identical( got, true );
+
+  var got = _.path.begins( '.src/a1', '.src' );
+  test.identical( got, true );
+
+  var got = _.path.begins( '.src/a1', '.src/' );
+  test.identical( got, true );
+
+  var got = _.path.begins( 'c:/src/a1', 'c:' );
+  test.identical( got, true );
+
+  var got = _.path.begins( '/C://src/a1', '/C:' );
+  test.identical( got, true );
+
+  var got = _.path.begins( 'foo/bar//baz/asdf/quux/..//.', 'foo' );
+  test.identical( got, true );
+  
+  var got = _.path.begins( 'foo/bar//baz/asdf/quux/..//.', 'foo/' );
+  test.identical( got, true );
+
+  test.case = 'Doesn´t begin';
+
+  var got = _.path.begins( 'ab', 'a' );
+  test.identical( got, false );
+
+  var got = _.path.begins( 'a/b', 'b' );
+  test.identical( got, false );
 
   var got = _.path.begins( 'this/is/some/path', '/this/is' );
   test.identical( got, false );
@@ -2194,17 +2256,54 @@ function begins( test )
   var got = _.path.begins( '/this/is/some/path', 'this/is/some/path' );
   test.identical( got, false );
 
-  var got = _.path.begins( '/this/is/some/path', '/this/is' );
-  test.identical( got, true );
-
-  var got = _.path.begins( '/this/is/some/path', '/this/is/some/path' );
-  test.identical( got, true );
-
   var got = _.path.begins( '/this/is/some/pathpath', '/this/is/some/path' );
   test.identical( got, false );
 
   var got = _.path.begins( '/this/is/some/path', '/this/is/some/pathpath' );
   test.identical( got, false );
+
+  var got = _.path.begins( 'c:/src/a1', '/c:' );
+  test.identical( got, false );
+
+  var got = _.path.begins( '/C://src/a1', 'C:' );
+  test.identical( got, false );
+
+  /* */
+
+  if( !Config.debug )
+  return;
+
+//  test.case = 'No arguments';
+//  test.shouldThrowError( () => _.path.begins( ) );
+
+  test.case = 'One argument';
+  test.shouldThrowError( () => _.path.begins( 'a' ) );
+
+//  test.case = 'Three arguments';
+//  test.shouldThrowError( () => _.path.begins( 'a', 'b', 'c' ) );
+
+  // Input is not path
+
+  test.case = 'No path - regexp';
+  test.shouldThrowError( () => _.path.begins( /foo/,  /foo/ ) );
+
+  test.case = 'No path - array';
+  test.shouldThrowError( () => _.path.begins( [ ], [ ] ) );
+
+  test.case = 'No path - object';
+  test.shouldThrowError( () => _.path.begins( { Path : 'C:/' }, { Path : 'C:/' } ) );
+
+//  test.case = 'No path - undefined';
+//  test.shouldThrowError( () => _.path.begins( undefined ) );
+
+  test.case = 'No path - null';
+  test.shouldThrowError( () => _.path.begins( null ) );
+
+  test.case = 'No path - NaN';
+  test.shouldThrowError( () => _.path.begins( NaN ) );
+
+  test.case = 'No path - NaN';
+  test.shouldThrowError( () => _.path.begins( NaN, NaN ) );
 
 }
 

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -21,15 +21,17 @@ var _ = _global_.wTools;
 function is( test )
 {
 
+  // Input is path
+
   test.case = 'Empty string';
   var expected = true;
   var got = _.path.is( '' );
   test.identical( got, expected );
 
-    test.case = 'Empty path';
-    var expected = true;
-    var got = _.path.is( '/' );
-    test.identical( got, expected );
+  test.case = 'Empty path';
+  var expected = true;
+  var got = _.path.is( '/' );
+  test.identical( got, expected );
 
   test.case = 'Simple string';
   var expected = true;
@@ -55,6 +57,8 @@ function is( test )
   var expected = true;
   var got = _.path.is( 'c:\\foo\\' );
   test.identical( got, expected );
+
+  // Input is not path
 
   test.case = 'No path - regexp';
   var expected = false;
@@ -101,6 +105,105 @@ function is( test )
 
   test.case = 'Two arguments';
   test.shouldThrowError( () => _.path.is( 'a', 'b' ) );
+
+}
+
+//
+
+function are( test )
+{
+
+  // Input is array
+
+  test.case = 'Empty array';
+  var expected = true;
+  var got = _.path.are( [ ] );
+  test.identical( got, expected );
+
+  test.case = 'Path in array';
+  var expected = true;
+  var got = _.path.are( [ '/C/work/f' ] );
+  test.identical( got, expected );
+
+  test.case = 'Paths in array';
+  var expected = true;
+  var got = _.path.are( [ '/C/', 'work/f' ] );
+  test.identical( got, expected );
+
+  test.case = 'Not a path in array';
+  var expected = false;
+  var got = _.path.are( [ 3 ] );
+  test.identical( got, expected );
+
+  test.case = 'Not only paths in array';
+  var expected = false;
+  var got = _.path.are( [ '/C/', 'work/f', 3 ] );
+  test.identical( got, expected );
+
+  // Input is object
+
+  test.case = 'Empty object';
+  var expected = true;
+  var got = _.path.are( {  } );
+  test.identical( got, expected );
+
+  test.case = 'Number in object';
+  var expected = true;
+  var got = _.path.are( { Path : 3 } );
+  test.identical( got, expected );
+
+  test.case = 'String in object';
+  var expected = true;
+  var got = _.path.are( { Path : 'Hello world' } );
+  test.identical( got, expected );
+
+  test.case = 'Several entries in object';
+  var expected = true;
+  var got = _.path.are( { Path1 : 0, Path2 : [ 'One', 'Two' ], Path3 : null, Path4 : undefined } );
+  test.identical( got, expected );
+
+  // Other input
+
+  test.case = 'No paths - string';
+  var expected = false;
+  var got = _.path.are( 'foo' );
+  test.identical( got, expected );
+
+  test.case = 'No paths - regexp';
+  var expected = false;
+  var got = _.path.are( /foo/ );
+  test.identical( got, expected );
+
+  test.case = 'No paths - number';
+  var expected = false;
+  var got = _.path.are( 3 );
+  test.identical( got, expected );
+
+  test.case = 'No paths - undefined';
+  var expected = false;
+  var got = _.path.are( undefined );
+  test.identical( got, expected );
+
+  test.case = 'No paths - null';
+  var expected = false;
+  var got = _.path.are( null );
+  test.identical( got, expected );
+
+  test.case = 'No paths - NaN';
+  var expected = false;
+  var got = _.path.are( NaN );
+  test.identical( got, expected );
+
+  /* */
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'No arguments';
+  test.shouldThrowError( () => _.path.are( ) );
+
+  test.case = 'Two arguments';
+  test.shouldThrowError( () => _.path.are( 'a', 'b' ) );
 
 }
 
@@ -3456,6 +3559,7 @@ var Self =
   {
 
     is,
+    are,
     isSafe,
     isRefined,
     isGlob,

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -18,6 +18,94 @@ var _ = _global_.wTools;
 
 //
 
+function is( test )
+{
+
+  test.case = 'Empty string';
+  var expected = true;
+  var got = _.path.is( '' );
+  test.identical( got, expected );
+
+    test.case = 'Empty path';
+    var expected = true;
+    var got = _.path.is( '/' );
+    test.identical( got, expected );
+
+  test.case = 'Simple string';
+  var expected = true;
+  var got = _.path.is( 'hello' );
+  test.identical( got, expected );
+
+  test.case = 'Simple path string';
+  var expected = true;
+  var got = _.path.is( '/D/work/f' );
+  test.identical( got, expected );
+
+  test.case = 'Relative path';
+  var expected = true;
+  var got = _.path.is( '/home/user/dir1/dir2' );
+  test.identical( got, expected );
+
+  test.case = 'Absolute path';
+  var expected = true;
+  var got = _.path.is( 'C:/foo/baz/bar' );
+  test.identical( got, expected );
+
+  test.case = 'Other path';
+  var expected = true;
+  var got = _.path.is( 'c:\\foo\\' );
+  test.identical( got, expected );
+
+  test.case = 'No path - regexp';
+  var expected = false;
+  var got = _.path.is( /foo/ );
+  test.identical( got, expected );
+
+  test.case = 'No path - number';
+  var expected = false;
+  var got = _.path.is( 3 );
+  test.identical( got, expected );
+
+  test.case = 'No path - array';
+  var expected = false;
+  var got = _.path.is( [ '/C/', 'work/f' ] );
+  test.identical( got, expected );
+
+  test.case = 'No path - object';
+  var expected = false;
+  var got = _.path.is( { Path : 'C:/foo/baz/bar' } );
+  test.identical( got, expected );
+
+  test.case = 'No path - undefined';
+  var expected = false;
+  var got = _.path.is( undefined );
+  test.identical( got, expected );
+
+  test.case = 'No path - null';
+  var expected = false;
+  var got = _.path.is( null );
+  test.identical( got, expected );
+
+  test.case = 'No path - NaN';
+  var expected = false;
+  var got = _.path.is( NaN );
+  test.identical( got, expected );
+
+  /* */
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'No arguments';
+  test.shouldThrowError( () => _.path.is( ) );
+
+  test.case = 'Two arguments';
+  test.shouldThrowError( () => _.path.is( 'a', 'b' ) );
+
+}
+
+//
+
 /* !!! example to avoid */
 
 function isSafe( test )
@@ -3367,6 +3455,7 @@ var Self =
   tests :
   {
 
+    is,
     isSafe,
     isRefined,
     isGlob,

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -1796,8 +1796,8 @@ function isGlobal( test )
   test.case = 'No arguments';
   test.shouldThrowError( () => _.path.isGlobal( ) );
 
-//  test.case = 'Two arguments';
-//  test.shouldThrowError( () => _.path.isGlobal( 'a', 'b' ) );
+  test.case = 'Two arguments';
+  test.shouldThrowError( () => _.path.isGlobal( 'a', 'b' ) );
 
   // Input is not path
 
@@ -2018,8 +2018,8 @@ function isDotted( test )
   test.case = 'No arguments';
   test.shouldThrowError( () => _.path.isDotted( ) );
 
-//  test.case = 'Two arguments';
-//  test.shouldThrowError( () => _.path.isDotted( 'a', 'b' ) );
+  test.case = 'Two arguments';
+  test.shouldThrowError( () => _.path.isDotted( 'a', 'b' ) );
 
   // Input is not path
 
@@ -2143,8 +2143,8 @@ function isTrailed( test )
   test.case = 'No arguments';
   test.shouldThrowError( () => _.path.isTrailed( ) );
 
-//  test.case = 'Two arguments';
-//  test.shouldThrowError( () => _.path.isTrailed( 'a', 'b' ) );
+  test.case = 'Two arguments';
+  test.shouldThrowError( () => _.path.isTrailed( 'a', 'b' ) );
 
   // Input is not path
 
@@ -2175,22 +2175,6 @@ function isTrailed( test )
 
 function begins( test )
 {
-
-  // qqq - should fail?
-
-  var got = _.path.begins(  );
-  test.identical( got, true );
-
-  var got = _.path.begins( undefined );
-  test.identical( got, true );
-
-  var got = _.path.begins( null, null );
-  test.identical( got, true );
-
-  var got = _.path.begins( 3, 3 );
-  test.identical( got, true );
-
-  //
 
   test.case = 'Same string';
 
@@ -2275,14 +2259,14 @@ function begins( test )
   if( !Config.debug )
   return;
 
-//  test.case = 'No arguments';
-//  test.shouldThrowError( () => _.path.begins( ) );
+  test.case = 'No arguments';
+  test.shouldThrowError( () => _.path.begins( ) );
 
   test.case = 'One argument';
   test.shouldThrowError( () => _.path.begins( 'a' ) );
 
-//  test.case = 'Three arguments';
-//  test.shouldThrowError( () => _.path.begins( 'a', 'b', 'c' ) );
+  test.case = 'Three arguments';
+  test.shouldThrowError( () => _.path.begins( 'a', 'b', 'c' ) );
 
   // Input is not path
 
@@ -2292,14 +2276,20 @@ function begins( test )
   test.case = 'No path - array';
   test.shouldThrowError( () => _.path.begins( [ ], [ ] ) );
 
+  test.case = 'No path - number';
+  test.shouldThrowError( () => _.path.begins( 3, 3 ) );
+
   test.case = 'No path - object';
   test.shouldThrowError( () => _.path.begins( { Path : 'C:/' }, { Path : 'C:/' } ) );
 
-//  test.case = 'No path - undefined';
-//  test.shouldThrowError( () => _.path.begins( undefined ) );
+  test.case = 'No path - undefined';
+  test.shouldThrowError( () => _.path.begins( undefined ) );
 
   test.case = 'No path - null';
   test.shouldThrowError( () => _.path.begins( null ) );
+
+  test.case = 'No path - null';
+  test.shouldThrowError( () => _.path.begins( null, null ) );
 
   test.case = 'No path - NaN';
   test.shouldThrowError( () => _.path.begins( NaN ) );
@@ -2433,8 +2423,8 @@ function ends( test )
   test.case = 'One argument';
   test.shouldThrowError( () => _.path.ends( 'a' ) );
 
-//  test.case = 'Three arguments';
-//  test.shouldThrowError( () => _.path.ends( 'a', 'b', 'c' ) );
+  test.case = 'Three arguments';
+  test.shouldThrowError( () => _.path.ends( 'a', 'b', 'c' ) );
 
   // Input is not path
 

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -1906,7 +1906,7 @@ function isRoot( test )
   test.shouldThrowError( () => _.path.isRoot( /foo/ ) );
 
   test.case = 'No path - number';
-  test.shouldThrowError( () => _.path.isGlobal( 3 ) );
+  test.shouldThrowError( () => _.path.isRoot( 3 ) );
 
   test.case = 'No path - array';
   test.shouldThrowError( () => _.path.isRoot( [ '/C/', 'work/f' ] ) );
@@ -1922,6 +1922,127 @@ function isRoot( test )
 
   test.case = 'No path - NaN';
   test.shouldThrowError( () => _.path.isRoot( NaN ) );
+
+}
+
+//
+
+function isDotted( test )
+{
+
+  test.case = 'Is Dotted';
+
+  var path = '.';
+  var got = _.path.isDotted( path );
+  test.identical( got, true );
+
+  var path = './';
+  var got = _.path.isDotted( path );
+  test.identical( got, true );
+
+  var path = './.';
+  var got = _.path.isDotted( path );
+  test.identical( got, true );
+
+  var path = '././';
+  var got = _.path.isDotted( path );
+  test.identical( got, true );
+
+  var path = './x/..';
+  var got = _.path.isDotted( path );
+  test.identical( got, true );
+
+  var path = './c';
+  var got = _.path.isDotted( path );
+  test.identical( got, true );
+
+  var path = '.src/a1';
+  var got = _.path.isDotted( path );
+  test.identical( got, true );
+
+  var path = '.c:/src/a1';
+  var got = _.path.isDotted( path );
+  test.identical( got, true );
+
+  var path = './C://src/a1';
+  var got = _.path.isDotted( path );
+  test.identical( got, true );
+
+  var path = '.foo/bar//baz/asdf/quux/..//.';
+  var got = _.path.isDotted( path );
+  test.identical( got, true );
+
+  test.case = 'Is not Dotted';
+
+  var path = '';
+  var got = _.path.isDotted( path );
+  test.identical( got, false );
+
+  var path = '/';
+  var got = _.path.isDotted( path );
+  test.identical( got, false );
+
+  var path = '/./.';
+  var got = _.path.isDotted( path );
+  test.identical( got, false );
+
+  var path = '/..';
+  var got = _.path.isDotted( path );
+  test.identical( got, false );
+
+  var path = '/c';
+  var got = _.path.isDotted( path );
+  test.identical( got, false );
+
+  var path = '/src/a1';
+  var got = _.path.isDotted( path );
+  test.identical( got, false );
+
+  var path = 'c:/src/a1';
+  var got = _.path.isDotted( path );
+  test.identical( got, false );
+
+  var path = '/C://src/a1';
+  var got = _.path.isDotted( path );
+  test.identical( got, false );
+
+  var path = 'foo/bar//baz/asdf/quux/..//.';
+  var got = _.path.isDotted( path );
+  test.identical( got, false );
+
+  /* */
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'No arguments';
+  test.shouldThrowError( () => _.path.isDotted( ) );
+
+//  test.case = 'Two arguments';
+//  test.shouldThrowError( () => _.path.isDotted( 'a', 'b' ) );
+
+  // Input is not path
+
+  test.case = 'No path - regexp';
+  test.shouldThrowError( () => _.path.isDotted( /foo/ ) );
+
+  test.case = 'No path - number';
+  test.shouldThrowError( () => _.path.isDotted( 3 ) );
+
+  test.case = 'No path - array';
+  test.shouldThrowError( () => _.path.isDotted( [ '/C/', 'work/f' ] ) );
+
+  test.case = 'No path - object';
+  test.shouldThrowError( () => _.path.isDotted( { Path : 'C:/foo/baz/bar' } ) );
+
+  test.case = 'No path - undefined';
+  test.shouldThrowError( () => _.path.isDotted( undefined ) );
+
+  test.case = 'No path - null';
+  test.shouldThrowError( () => _.path.isDotted( null ) );
+
+  test.case = 'No path - NaN';
+  test.shouldThrowError( () => _.path.isDotted( NaN ) );
 
 }
 
@@ -4696,6 +4817,7 @@ var Self =
     isRelative,
     isGlobal,
     isRoot,
+    isDotted,
 
     begins,
     ends,

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -18,282 +18,122 @@ var _ = _global_.wTools;
 
 //
 
-function refine( test )
+/* !!! example to avoid */
+
+function isSafe( test )
 {
-  var got;
+  var path1 = '/home/user/dir1/dir2',
+    path2 = 'C:/foo/baz/bar',
+    path3 = '/foo/bar/.hidden',
+    path4 = '/foo/./somedir',
+    path5 = 'c:/foo/',
+    path6 = 'c:\\foo\\',
+    path7 = '/',
+    path8 = '/a',
+    got;
 
-  test.case = 'posix path'; /* */
+  test.case = 'safe windows path, level:2';
+  var got = _.path.isSafe( '/D/work/f', 2 );
+  test.identical( got, process.platform === 'win32' ? false : true );
 
-  var path = '/foo/bar//baz/asdf/quux/..';
-  var expected = '/foo/bar//baz/asdf/quux/..';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  test.case = 'safe windows path, level:1';
+  var got = _.path.isSafe( '/D/work/f', 1 );
+  test.identical( got, true );
 
-  var path = '/foo/bar//baz/asdf/quux/../';
-  var expected = '/foo/bar//baz/asdf/quux/..';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  test.case = 'safe posix path';
+  var got = _.path.isSafe( path1 );
+  test.identical( got, true );
 
-  var path = '//foo/bar//baz/asdf/quux/..//';
-  var expected = '//foo/bar//baz/asdf/quux/..//';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  test.case = 'safe windows path';
+  var got = _.path.isSafe( path2 );
+  test.identical( got, true );
 
-  var path = 'foo/bar//baz/asdf/quux/..//.';
-  var expected = 'foo/bar//baz/asdf/quux/..//.';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  // test.case = 'unsafe posix path ( hidden )';
+  // var got = _.path.isSafe( path3 );
+  // test.identical( got, false );
 
-  test.case = 'winoows path'; /* */
+  test.case = 'safe posix path with "." segment';
+  var got = _.path.isSafe( path4 );
+  test.identical( got, true );
 
-  var path = 'C:\\';
-  var expected = '/C';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  test.case = 'unsafe windows path';
+  var got = _.path.isSafe( path5 );
+  test.identical( got, false );
 
-  var path = 'C:';
-  var expected = '/C';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  test.case = 'unsafe windows path';
+  var got = _.path.isSafe( path6 );
+  test.identical( got, false );
 
-  var path = 'C:\\temp\\\\foo\\bar\\..\\';
-  var expected = '/C/temp//foo/bar/..';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  test.case = 'unsafe short path';
+  var got = _.path.isSafe( path7 );
+  test.identical( got, false );
 
-  var path = 'C:\\temp\\\\foo\\bar\\..\\\\';
-  var expected = '/C/temp//foo/bar/..//';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  test.case = 'unsafe short path';
+  var got = _.path.isSafe( path8 );
+  test.identical( got, false );
 
-  var path = 'C:\\temp\\\\foo\\bar\\..\\\\';
-  var expected = '/C/temp//foo/bar/..//';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  /* - */
 
-  var path = 'C:\\temp\\\\foo\\bar\\..\\..\\';
-  var expected = '/C/temp//foo/bar/../..';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  test.case = 'unsafe short path';
+  var got = _.path.isSafe( '/dir1/dir2', 2 );
+  test.identical( got, false );
 
-  var path = 'C:\\temp\\\\foo\\bar\\..\\..\\.';
-  var expected = '/C/temp//foo/bar/../../.';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  test.case = 'unsafe short path';
+  var got = _.path.isSafe( '/dir1/dir2', 1 );
+  test.identical( got, true );
 
-  test.case = 'empty path'; /* */
+  test.case = 'unsafe short path';
+  var got = _.path.isSafe( '/dir1', 1 );
+  test.identical( got, false );
 
-  var path = '';
-  var expected = '.';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  /* - */
 
-  var path = '/';
-  var expected = '/';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  test.open( 'windows only' );
 
-  var path = '//';
-  var expected = '//';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  if( process.platform === 'win32' )
+  {
 
-  var path = '///';
-  var expected = '///';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+    var got = _.path.isSafe( '/c/Windows' );
+    test.identical( got, false );
 
-  var path = '/.';
-  var expected = '/.';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+    var got = _.path.isSafe( '/C/Windows' );
+    test.identical( got, false );
 
-  var path = '/./.';
-  var expected = '/./.';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+    var got = _.path.isSafe( '/c/Program Files' );
+    test.identical( got, false );
 
-  var path = '.';
-  var expected = '.';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+    var got = _.path.isSafe( '/C/Program Files' );
+    test.identical( got, false );
 
-  var path = './.';
-  var expected = './.';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+    var got = _.path.isSafe( 'C:\\Program Files (x86)' );
+    test.identical( got, false );
 
-  test.case = 'path with "." in the middle'; /* */
+  }
 
-  var path = 'foo/./bar/baz';
-  var expected = 'foo/./bar/baz';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  test.close( 'windows only' );
 
-  var path = 'foo/././bar/baz/';
-  var expected = 'foo/././bar/baz';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  /* - */
 
-  var path = 'foo/././bar/././baz/';
-  var expected = 'foo/././bar/././baz';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  if( !Config.debug )
+  return;
 
-  var path = '/foo/././bar/././baz/';
-  var expected = '/foo/././bar/././baz';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  test.case = 'missed arguments';
+  test.shouldThrowErrorSync( function( )
+  {
+    _.path.isSafe( );
+  });
 
-  test.case = 'path with "." in the beginning'; /* */
+  test.case = 'argument is not string';
+  test.shouldThrowErrorSync( function( )
+  {
+    _.path.isSafe( null );
+  });
 
-  var path = './foo/bar';
-  var expected = './foo/bar';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = '././foo/bar/';
-  var expected = '././foo/bar';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = './/.//foo/bar/';
-  var expected = './/.//foo/bar';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = '/.//.//foo/bar/';
-  var expected = '/.//.//foo/bar';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = '.x/foo/bar';
-  var expected = '.x/foo/bar';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = '.x./foo/bar';
-  var expected = '.x./foo/bar';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  test.case = 'path with "." in the end'; /* */
-
-  var path = 'foo/bar.';
-  var expected = 'foo/bar.';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = 'foo/.bar.';
-  var expected = 'foo/.bar.';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = 'foo/bar/.';
-  var expected = 'foo/bar/.';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = 'foo/bar/./.';
-  var expected = 'foo/bar/./.';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = 'foo/bar/././';
-  var expected = 'foo/bar/./.';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = '/foo/bar/././';
-  var expected = '/foo/bar/./.';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  test.case = 'path with ".." in the middle'; /* */
-
-  var path = 'foo/../bar/baz';
-  var expected = 'foo/../bar/baz';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = 'foo/../../bar/baz/';
-  var expected = 'foo/../../bar/baz';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = 'foo/../../bar/../../baz/';
-  var expected = 'foo/../../bar/../../baz';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = '/foo/../../bar/../../baz/';
-  var expected = '/foo/../../bar/../../baz';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  test.case = 'path with ".." in the beginning'; /* */
-
-  var path = '../foo/bar';
-  var expected = '../foo/bar';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = '../../foo/bar/';
-  var expected = '../../foo/bar';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = '..//..//foo/bar/';
-  var expected = '..//..//foo/bar';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = '/..//..//foo/bar/';
-  var expected = '/..//..//foo/bar';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = '..x/foo/bar';
-  var expected = '..x/foo/bar';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = '..x../foo/bar';
-  var expected = '..x../foo/bar';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  test.case = 'path with ".." in the end'; /* */
-
-  var path = 'foo/bar..';
-  var expected = 'foo/bar..';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = 'foo/..bar..';
-  var expected = 'foo/..bar..';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = 'foo/bar/..';
-  var expected = 'foo/bar/..';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = 'foo/bar/../..';
-  var expected = 'foo/bar/../..';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = 'foo/bar/../../';
-  var expected = 'foo/bar/../..';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
-
-  var path = '/foo/bar/../../';
-  var expected = '/foo/bar/../..';
-  var got = _.path.refine( path );
-  test.identical( got, expected );
+  test.case = 'too macny arguments';
+  test.shouldThrowErrorSync( function( )
+  {
+    _.path.isSafe( '/a/b','/a/b' );
+  });
 
 }
 
@@ -669,127 +509,6 @@ function isRefined( test )
 
 //
 
-/* !!! example to avoid */
-
-function isSafe( test )
-{
-  var path1 = '/home/user/dir1/dir2',
-    path2 = 'C:/foo/baz/bar',
-    path3 = '/foo/bar/.hidden',
-    path4 = '/foo/./somedir',
-    path5 = 'c:/foo/',
-    path6 = 'c:\\foo\\',
-    path7 = '/',
-    path8 = '/a',
-    got;
-
-  test.case = 'safe windows path, level:2';
-  var got = _.path.isSafe( '/D/work/f', 2 );
-  test.identical( got, process.platform === 'win32' ? false : true );
-
-  test.case = 'safe windows path, level:1';
-  var got = _.path.isSafe( '/D/work/f', 1 );
-  test.identical( got, true );
-
-  test.case = 'safe posix path';
-  var got = _.path.isSafe( path1 );
-  test.identical( got, true );
-
-  test.case = 'safe windows path';
-  var got = _.path.isSafe( path2 );
-  test.identical( got, true );
-
-  // test.case = 'unsafe posix path ( hidden )';
-  // var got = _.path.isSafe( path3 );
-  // test.identical( got, false );
-
-  test.case = 'safe posix path with "." segment';
-  var got = _.path.isSafe( path4 );
-  test.identical( got, true );
-
-  test.case = 'unsafe windows path';
-  var got = _.path.isSafe( path5 );
-  test.identical( got, false );
-
-  test.case = 'unsafe windows path';
-  var got = _.path.isSafe( path6 );
-  test.identical( got, false );
-
-  test.case = 'unsafe short path';
-  var got = _.path.isSafe( path7 );
-  test.identical( got, false );
-
-  test.case = 'unsafe short path';
-  var got = _.path.isSafe( path8 );
-  test.identical( got, false );
-
-  /* - */
-
-  test.case = 'unsafe short path';
-  var got = _.path.isSafe( '/dir1/dir2', 2 );
-  test.identical( got, false );
-
-  test.case = 'unsafe short path';
-  var got = _.path.isSafe( '/dir1/dir2', 1 );
-  test.identical( got, true );
-
-  test.case = 'unsafe short path';
-  var got = _.path.isSafe( '/dir1', 1 );
-  test.identical( got, false );
-
-  /* - */
-
-  test.open( 'windows only' );
-
-  if( process.platform === 'win32' )
-  {
-
-    var got = _.path.isSafe( '/c/Windows' );
-    test.identical( got, false );
-
-    var got = _.path.isSafe( '/C/Windows' );
-    test.identical( got, false );
-
-    var got = _.path.isSafe( '/c/Program Files' );
-    test.identical( got, false );
-
-    var got = _.path.isSafe( '/C/Program Files' );
-    test.identical( got, false );
-
-    var got = _.path.isSafe( 'C:\\Program Files (x86)' );
-    test.identical( got, false );
-
-  }
-
-  test.close( 'windows only' );
-
-  /* - */
-
-  if( !Config.debug )
-  return;
-
-  test.case = 'missed arguments';
-  test.shouldThrowErrorSync( function( )
-  {
-    _.path.isSafe( );
-  });
-
-  test.case = 'argument is not string';
-  test.shouldThrowErrorSync( function( )
-  {
-    _.path.isSafe( null );
-  });
-
-  test.case = 'too macny arguments';
-  test.shouldThrowErrorSync( function( )
-  {
-    _.path.isSafe( '/a/b','/a/b' );
-  });
-
-}
-
-//
-
 function isGlob( test )
 {
 
@@ -884,6 +603,358 @@ function isRoot( test )
   var path = '/x/..';
   var got = _.path.isRoot( path );
   test.identical( got, true );
+
+}
+
+//
+
+function begins( test )
+{
+
+  var got = _.path.begins( 'this/is/some/path', 'this/is' );
+  test.identical( got, true );
+
+  var got = _.path.begins( 'this/is/some/path', 'this/is/some/path' );
+  test.identical( got, true );
+
+  var got = _.path.begins( 'this/is/some/path', '/this/is' );
+  test.identical( got, false );
+
+  var got = _.path.begins( 'this/is/some/path', '/this/is/some/path' );
+  test.identical( got, false );
+
+  var got = _.path.begins( '/this/is/some/path', 'this/is' );
+  test.identical( got, false );
+
+  var got = _.path.begins( '/this/is/some/path', 'this/is/some/path' );
+  test.identical( got, false );
+
+  var got = _.path.begins( '/this/is/some/path', '/this/is' );
+  test.identical( got, true );
+
+  var got = _.path.begins( '/this/is/some/path', '/this/is/some/path' );
+  test.identical( got, true );
+
+  var got = _.path.begins( '/this/is/some/pathpath', '/this/is/some/path' );
+  test.identical( got, false );
+
+  var got = _.path.begins( '/this/is/some/path', '/this/is/some/pathpath' );
+  test.identical( got, false );
+
+}
+
+//
+
+function ends( test )
+{
+
+  var got = _.path.ends( 'this/is/some/path', 'some/path' );
+  test.identical( got, true );
+
+  var got = _.path.ends( 'this/is/some/path', 'this/is/some/path' );
+  test.identical( got, true );
+
+  var got = _.path.ends( '/this/is/some/path', 'some/path' );
+  test.identical( got, true );
+
+  var got = _.path.ends( '/this/is/some/path', 'this/is/some/path' );
+  test.identical( got, true );
+
+  var got = _.path.ends( 'this/is/some/path', '/some/path' );
+  test.identical( got, false );
+
+  var got = _.path.ends( 'this/is/some/path', '/this/is/some/path' );
+  test.identical( got, false );
+
+  var got = _.path.ends( '/this/is/some/path', '/some/path' );
+  test.identical( got, false );
+
+  var got = _.path.ends( '/this/is/some/path', '/this/is/some/path' );
+  test.identical( got, true );
+
+  var got = _.path.ends( 'this/is/some/pathpath', 'path' );
+  test.identical( got, false );
+
+}
+
+//
+
+function refine( test )
+{
+  var got;
+
+  test.case = 'posix path'; /* */
+
+  var path = '/foo/bar//baz/asdf/quux/..';
+  var expected = '/foo/bar//baz/asdf/quux/..';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '/foo/bar//baz/asdf/quux/../';
+  var expected = '/foo/bar//baz/asdf/quux/..';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '//foo/bar//baz/asdf/quux/..//';
+  var expected = '//foo/bar//baz/asdf/quux/..//';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'foo/bar//baz/asdf/quux/..//.';
+  var expected = 'foo/bar//baz/asdf/quux/..//.';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  test.case = 'winoows path'; /* */
+
+  var path = 'C:\\';
+  var expected = '/C';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'C:';
+  var expected = '/C';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'C:\\temp\\\\foo\\bar\\..\\';
+  var expected = '/C/temp//foo/bar/..';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'C:\\temp\\\\foo\\bar\\..\\\\';
+  var expected = '/C/temp//foo/bar/..//';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'C:\\temp\\\\foo\\bar\\..\\\\';
+  var expected = '/C/temp//foo/bar/..//';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'C:\\temp\\\\foo\\bar\\..\\..\\';
+  var expected = '/C/temp//foo/bar/../..';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'C:\\temp\\\\foo\\bar\\..\\..\\.';
+  var expected = '/C/temp//foo/bar/../../.';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  test.case = 'empty path'; /* */
+
+  var path = '';
+  var expected = '.';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '/';
+  var expected = '/';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '//';
+  var expected = '//';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '///';
+  var expected = '///';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '/.';
+  var expected = '/.';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '/./.';
+  var expected = '/./.';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '.';
+  var expected = '.';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = './.';
+  var expected = './.';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  test.case = 'path with "." in the middle'; /* */
+
+  var path = 'foo/./bar/baz';
+  var expected = 'foo/./bar/baz';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'foo/././bar/baz/';
+  var expected = 'foo/././bar/baz';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'foo/././bar/././baz/';
+  var expected = 'foo/././bar/././baz';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '/foo/././bar/././baz/';
+  var expected = '/foo/././bar/././baz';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  test.case = 'path with "." in the beginning'; /* */
+
+  var path = './foo/bar';
+  var expected = './foo/bar';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '././foo/bar/';
+  var expected = '././foo/bar';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = './/.//foo/bar/';
+  var expected = './/.//foo/bar';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '/.//.//foo/bar/';
+  var expected = '/.//.//foo/bar';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '.x/foo/bar';
+  var expected = '.x/foo/bar';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '.x./foo/bar';
+  var expected = '.x./foo/bar';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  test.case = 'path with "." in the end'; /* */
+
+  var path = 'foo/bar.';
+  var expected = 'foo/bar.';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'foo/.bar.';
+  var expected = 'foo/.bar.';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'foo/bar/.';
+  var expected = 'foo/bar/.';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'foo/bar/./.';
+  var expected = 'foo/bar/./.';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'foo/bar/././';
+  var expected = 'foo/bar/./.';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '/foo/bar/././';
+  var expected = '/foo/bar/./.';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  test.case = 'path with ".." in the middle'; /* */
+
+  var path = 'foo/../bar/baz';
+  var expected = 'foo/../bar/baz';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'foo/../../bar/baz/';
+  var expected = 'foo/../../bar/baz';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'foo/../../bar/../../baz/';
+  var expected = 'foo/../../bar/../../baz';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '/foo/../../bar/../../baz/';
+  var expected = '/foo/../../bar/../../baz';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  test.case = 'path with ".." in the beginning'; /* */
+
+  var path = '../foo/bar';
+  var expected = '../foo/bar';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '../../foo/bar/';
+  var expected = '../../foo/bar';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '..//..//foo/bar/';
+  var expected = '..//..//foo/bar';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '/..//..//foo/bar/';
+  var expected = '/..//..//foo/bar';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '..x/foo/bar';
+  var expected = '..x/foo/bar';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '..x../foo/bar';
+  var expected = '..x../foo/bar';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  test.case = 'path with ".." in the end'; /* */
+
+  var path = 'foo/bar..';
+  var expected = 'foo/bar..';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'foo/..bar..';
+  var expected = 'foo/..bar..';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'foo/bar/..';
+  var expected = 'foo/bar/..';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'foo/bar/../..';
+  var expected = 'foo/bar/../..';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = 'foo/bar/../../';
+  var expected = 'foo/bar/../..';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
+
+  var path = '/foo/bar/../../';
+  var expected = '/foo/bar/../..';
+  var got = _.path.refine( path );
+  test.identical( got, expected );
 
 }
 
@@ -2178,256 +2249,6 @@ function resolve( test )
 
 //
 
-function dir( test )
-{
-
-  test.case = 'simple absolute path'; /* */
-
-  var path2 = '/foo';
-  var expected2 = '/';
-  var got = _.path.dir( path2 );
-  test.identical( got, expected2 );
-
-  test.case = 'absolute path : nested dirs'; /* */
-
-  var path = '/foo/bar/baz/text.txt';
-  var expected = '/foo/bar/baz';
-  var got = _.path.dir( path );
-  test.identical( got, expected );
-
-  var path = '/aa/bb';
-  var expected = '/aa';
-  var got = _.path.dir( path );
-  test.identical( got, expected );
-
-  var path = '/aa/bb/';
-  var expected = '/aa';
-  var got = _.path.dir( path );
-  test.identical( got, expected );
-
-  var path = '/aa';
-  var expected = '/';
-  var got = _.path.dir( path );
-  test.identical( got, expected );
-
-  var path = '/';
-  var expected = '/..';
-  var got = _.path.dir( path );
-  test.identical( got, expected );
-
-  test.case = 'relative path : nested dirs'; /* */
-
-  var path = 'aa/bb';
-  var expected = 'aa';
-  var got = _.path.dir( path );
-  test.identical( got, expected );
-
-  var path = 'aa';
-  var expected = '.';
-  var got = _.path.dir( path );
-  test.identical( got, expected );
-
-  var path = '.';
-  var expected = '..';
-  var got = _.path.dir( path );
-  test.identical( got, expected );
-
-  var path = '..';
-  var expected = '../..';
-  var got = _.path.dir( path );
-  test.identical( got, expected );
-
-  // test.case = 'windows os path';
-  // var path4 = 'c:/';
-  // var expected4 = 'c:/..';
-  // var got = _.path.dir( path4 );
-  // test.identical( got, expected4 );
-
-  // test.case = 'windows os path : nested dirs';
-  // var path5 = 'a:/foo/baz/bar.txt';
-  // var expected5 = 'a:/foo/baz';
-  // var got = _.path.dir( path5 );
-  // test.identical( got, expected5 );
-
-  if( !Config.debug )
-  return;
-
-  test.case = 'empty path';
-  test.shouldThrowErrorSync( function()
-  {
-    var got = _.path.dir( '' );
-  });
-
-  test.case = 'redundant argument';
-  test.shouldThrowErrorSync( function()
-  {
-    var got = _.path.dir( 'a','b' );
-  });
-
-  test.case = 'passed argument is non string';
-  test.shouldThrowErrorSync( function()
-  {
-    _.path.dir( {} );
-  });
-
-}
-
-//
-
-function ext( test )
-{
-  var path1 = '',
-    path2 = 'some.txt',
-    path3 = '/foo/bar/baz.asdf',
-    path4 = '/foo/bar/.baz',
-    path5 = '/foo.coffee.md',
-    path6 = '/foo/bar/baz',
-    expected1 = '',
-    expected2 = 'txt',
-    expected3 = 'asdf',
-    expected4 = '',
-    expected5 = 'md',
-    expected6 = '';
-
-  test.case = 'empty path';
-  var got = _.path.ext( path1 );
-  test.identical( got, expected1 );
-
-  test.case = 'txt extension';
-  var got = _.path.ext( path2 );
-  test.identical( got, expected2 );
-
-  test.case = 'path with non empty dir name';
-  var got = _.path.ext( path3 );
-  test.identical( got, expected3) ;
-
-  test.case = 'hidden file';
-  var got = _.path.ext( path4 );
-  test.identical( got, expected4 );
-
-  test.case = 'several extension';
-  var got = _.path.ext( path5 );
-  test.identical( got, expected5 );
-
-  test.case = 'file without extension';
-  var got = _.path.ext( path6 );
-  test.identical( got, expected6 );
-
-  if( !Config.debug )
-  return;
-
-  test.case = 'passed argument is non string';
-  test.shouldThrowErrorSync( function()
-  {
-    _.path.ext( null );
-  });
-
-}
-
-//
-
-function prefixGet( test )
-{
-  var path1 = '',
-    path2 = 'some.txt',
-    path3 = '/foo/bar/baz.asdf',
-    path4 = '/foo/bar/.baz',
-    path5 = '/foo.coffee.md',
-    path6 = '/foo/bar/baz',
-    expected1 = '',
-    expected2 = 'some',
-    expected3 = '/foo/bar/baz',
-    expected4 = '/foo/bar/',
-    expected5 = '/foo',
-    expected6 = '/foo/bar/baz';
-
-  test.case = 'empty path';
-  var got = _.path.prefixGet( path1 );
-  test.identical( got, expected1 );
-
-  test.case = 'txt extension';
-  var got = _.path.prefixGet( path2 );
-  test.identical( got, expected2 );
-
-  test.case = 'path with non empty dir name';
-  var got = _.path.prefixGet( path3 );
-  test.identical( got, expected3 ) ;
-
-  test.case = 'hidden file';
-  var got = _.path.prefixGet( path4 );
-  test.identical( got, expected4 );
-
-  test.case = 'several extension';
-  var got = _.path.prefixGet( path5 );
-  test.identical( got, expected5 );
-
-  test.case = 'file without extension';
-  var got = _.path.prefixGet( path6 );
-  test.identical( got, expected6 );
-
-  if( !Config.debug )
-  return;
-
-  test.case = 'passed argument is non string';
-  test.shouldThrowErrorSync( function()
-  {
-    _.path.prefixGet( null );
-  });
-};
-
-//
-
-function name( test )
-{
-  var path1 = '',
-    path2 = 'some.txt',
-    path3 = '/foo/bar/baz.asdf',
-    path4 = '/foo/bar/.baz',
-    path5 = '/foo.coffee.md',
-    path6 = '/foo/bar/baz',
-    expected1 = '',
-    expected2 = 'some.txt',
-    expected3 = 'baz',
-    expected4 = '.baz',
-    expected5 = 'foo.coffee',
-    expected6 = 'baz';
-
-  test.case = 'empty path';
-  var got = _.path.name( path1 );
-  test.identical( got, expected1 );
-
-  test.case = 'get file with extension';
-  var got = _.path.name({ path : path2, withExtension : 1 } );
-  test.identical( got, expected2 );
-
-  test.case = 'got file without extension';
-  var got = _.path.name({ path : path3, withExtension : 0 } );
-  test.identical( got, expected3) ;
-
-  test.case = 'hidden file';
-  var got = _.path.name({ path : path4, withExtension : 1 } );
-  test.identical( got, expected4 );
-
-  test.case = 'several extension';
-  var got = _.path.name( path5 );
-  test.identical( got, expected5 );
-
-  test.case = 'file without extension';
-  var got = _.path.name( path6 );
-  test.identical( got, expected6 );
-
-  if( !Config.debug )
-  return;
-
-  test.case = 'passed argument is non string';
-  test.shouldThrowErrorSync( function()
-  {
-    _.path.name( false );
-  });
-};
-
-//
-
 function joinNames( test )
 {
 
@@ -2630,6 +2451,204 @@ function joinNames( test )
   test.shouldThrowError( () => _.path.joinNames( [ '1', 'a' ] ) );
   test.shouldThrowError( () => _.path.joinNames( '/a/a', '/b/b', 'c/c' ) );
 
+};
+
+//
+
+function dir( test )
+{
+
+  test.case = 'simple absolute path'; /* */
+
+  var path2 = '/foo';
+  var expected2 = '/';
+  var got = _.path.dir( path2 );
+  test.identical( got, expected2 );
+
+  test.case = 'absolute path : nested dirs'; /* */
+
+  var path = '/foo/bar/baz/text.txt';
+  var expected = '/foo/bar/baz';
+  var got = _.path.dir( path );
+  test.identical( got, expected );
+
+  var path = '/aa/bb';
+  var expected = '/aa';
+  var got = _.path.dir( path );
+  test.identical( got, expected );
+
+  var path = '/aa/bb/';
+  var expected = '/aa';
+  var got = _.path.dir( path );
+  test.identical( got, expected );
+
+  var path = '/aa';
+  var expected = '/';
+  var got = _.path.dir( path );
+  test.identical( got, expected );
+
+  var path = '/';
+  var expected = '/..';
+  var got = _.path.dir( path );
+  test.identical( got, expected );
+
+  test.case = 'relative path : nested dirs'; /* */
+
+  var path = 'aa/bb';
+  var expected = 'aa';
+  var got = _.path.dir( path );
+  test.identical( got, expected );
+
+  var path = 'aa';
+  var expected = '.';
+  var got = _.path.dir( path );
+  test.identical( got, expected );
+
+  var path = '.';
+  var expected = '..';
+  var got = _.path.dir( path );
+  test.identical( got, expected );
+
+  var path = '..';
+  var expected = '../..';
+  var got = _.path.dir( path );
+  test.identical( got, expected );
+
+  // test.case = 'windows os path';
+  // var path4 = 'c:/';
+  // var expected4 = 'c:/..';
+  // var got = _.path.dir( path4 );
+  // test.identical( got, expected4 );
+
+  // test.case = 'windows os path : nested dirs';
+  // var path5 = 'a:/foo/baz/bar.txt';
+  // var expected5 = 'a:/foo/baz';
+  // var got = _.path.dir( path5 );
+  // test.identical( got, expected5 );
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'empty path';
+  test.shouldThrowErrorSync( function()
+  {
+    var got = _.path.dir( '' );
+  });
+
+  test.case = 'redundant argument';
+  test.shouldThrowErrorSync( function()
+  {
+    var got = _.path.dir( 'a','b' );
+  });
+
+  test.case = 'passed argument is non string';
+  test.shouldThrowErrorSync( function()
+  {
+    _.path.dir( {} );
+  });
+
+}
+
+//
+
+function prefixGet( test )
+{
+  var path1 = '',
+    path2 = 'some.txt',
+    path3 = '/foo/bar/baz.asdf',
+    path4 = '/foo/bar/.baz',
+    path5 = '/foo.coffee.md',
+    path6 = '/foo/bar/baz',
+    expected1 = '',
+    expected2 = 'some',
+    expected3 = '/foo/bar/baz',
+    expected4 = '/foo/bar/',
+    expected5 = '/foo',
+    expected6 = '/foo/bar/baz';
+
+  test.case = 'empty path';
+  var got = _.path.prefixGet( path1 );
+  test.identical( got, expected1 );
+
+  test.case = 'txt extension';
+  var got = _.path.prefixGet( path2 );
+  test.identical( got, expected2 );
+
+  test.case = 'path with non empty dir name';
+  var got = _.path.prefixGet( path3 );
+  test.identical( got, expected3 ) ;
+
+  test.case = 'hidden file';
+  var got = _.path.prefixGet( path4 );
+  test.identical( got, expected4 );
+
+  test.case = 'several extension';
+  var got = _.path.prefixGet( path5 );
+  test.identical( got, expected5 );
+
+  test.case = 'file without extension';
+  var got = _.path.prefixGet( path6 );
+  test.identical( got, expected6 );
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'passed argument is non string';
+  test.shouldThrowErrorSync( function()
+  {
+    _.path.prefixGet( null );
+  });
+};
+
+//
+
+function name( test )
+{
+  var path1 = '',
+    path2 = 'some.txt',
+    path3 = '/foo/bar/baz.asdf',
+    path4 = '/foo/bar/.baz',
+    path5 = '/foo.coffee.md',
+    path6 = '/foo/bar/baz',
+    expected1 = '',
+    expected2 = 'some.txt',
+    expected3 = 'baz',
+    expected4 = '.baz',
+    expected5 = 'foo.coffee',
+    expected6 = 'baz';
+
+  test.case = 'empty path';
+  var got = _.path.name( path1 );
+  test.identical( got, expected1 );
+
+  test.case = 'get file with extension';
+  var got = _.path.name({ path : path2, withExtension : 1 } );
+  test.identical( got, expected2 );
+
+  test.case = 'got file without extension';
+  var got = _.path.name({ path : path3, withExtension : 0 } );
+  test.identical( got, expected3) ;
+
+  test.case = 'hidden file';
+  var got = _.path.name({ path : path4, withExtension : 1 } );
+  test.identical( got, expected4 );
+
+  test.case = 'several extension';
+  var got = _.path.name( path5 );
+  test.identical( got, expected5 );
+
+  test.case = 'file without extension';
+  var got = _.path.name( path6 );
+  test.identical( got, expected6 );
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'passed argument is non string';
+  test.shouldThrowErrorSync( function()
+  {
+    _.path.name( false );
+  });
 };
 
 //
@@ -2853,6 +2872,58 @@ function changeExt( test )
   test.shouldThrowErrorSync( function()
   {
     _.path.changeExt( null, '' );
+  });
+
+}
+
+//
+
+function ext( test )
+{
+  var path1 = '',
+    path2 = 'some.txt',
+    path3 = '/foo/bar/baz.asdf',
+    path4 = '/foo/bar/.baz',
+    path5 = '/foo.coffee.md',
+    path6 = '/foo/bar/baz',
+    expected1 = '',
+    expected2 = 'txt',
+    expected3 = 'asdf',
+    expected4 = '',
+    expected5 = 'md',
+    expected6 = '';
+
+  test.case = 'empty path';
+  var got = _.path.ext( path1 );
+  test.identical( got, expected1 );
+
+  test.case = 'txt extension';
+  var got = _.path.ext( path2 );
+  test.identical( got, expected2 );
+
+  test.case = 'path with non empty dir name';
+  var got = _.path.ext( path3 );
+  test.identical( got, expected3) ;
+
+  test.case = 'hidden file';
+  var got = _.path.ext( path4 );
+  test.identical( got, expected4 );
+
+  test.case = 'several extension';
+  var got = _.path.ext( path5 );
+  test.identical( got, expected5 );
+
+  test.case = 'file without extension';
+  var got = _.path.ext( path6 );
+  test.identical( got, expected6 );
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'passed argument is non string';
+  test.shouldThrowErrorSync( function()
+  {
+    _.path.ext( null );
   });
 
 }
@@ -3283,77 +3354,6 @@ function common( test )
 
 }
 
-//
-
-function begins( test )
-{
-
-  var got = _.path.begins( 'this/is/some/path', 'this/is' );
-  test.identical( got, true );
-
-  var got = _.path.begins( 'this/is/some/path', 'this/is/some/path' );
-  test.identical( got, true );
-
-  var got = _.path.begins( 'this/is/some/path', '/this/is' );
-  test.identical( got, false );
-
-  var got = _.path.begins( 'this/is/some/path', '/this/is/some/path' );
-  test.identical( got, false );
-
-  var got = _.path.begins( '/this/is/some/path', 'this/is' );
-  test.identical( got, false );
-
-  var got = _.path.begins( '/this/is/some/path', 'this/is/some/path' );
-  test.identical( got, false );
-
-  var got = _.path.begins( '/this/is/some/path', '/this/is' );
-  test.identical( got, true );
-
-  var got = _.path.begins( '/this/is/some/path', '/this/is/some/path' );
-  test.identical( got, true );
-
-  var got = _.path.begins( '/this/is/some/pathpath', '/this/is/some/path' );
-  test.identical( got, false );
-
-  var got = _.path.begins( '/this/is/some/path', '/this/is/some/pathpath' );
-  test.identical( got, false );
-
-}
-
-//
-
-function ends( test )
-{
-
-  var got = _.path.ends( 'this/is/some/path', 'some/path' );
-  test.identical( got, true );
-
-  var got = _.path.ends( 'this/is/some/path', 'this/is/some/path' );
-  test.identical( got, true );
-
-  var got = _.path.ends( '/this/is/some/path', 'some/path' );
-  test.identical( got, true );
-
-  var got = _.path.ends( '/this/is/some/path', 'this/is/some/path' );
-  test.identical( got, true );
-
-  var got = _.path.ends( 'this/is/some/path', '/some/path' );
-  test.identical( got, false );
-
-  var got = _.path.ends( 'this/is/some/path', '/this/is/some/path' );
-  test.identical( got, false );
-
-  var got = _.path.ends( '/this/is/some/path', '/some/path' );
-  test.identical( got, false );
-
-  var got = _.path.ends( '/this/is/some/path', '/this/is/some/path' );
-  test.identical( got, true );
-
-  var got = _.path.ends( 'this/is/some/pathpath', 'path' );
-  test.identical( got, false );
-
-}
-
 // --
 // declare
 // --
@@ -3367,12 +3367,15 @@ var Self =
   tests :
   {
 
-    refine,
-
-    isRefined,
     isSafe,
+    isRefined,
     isGlob,
     isRoot,
+
+    begins,
+    ends,
+
+    refine,
 
     normalize,
     normalizeTolerant,
@@ -3385,21 +3388,18 @@ var Self =
     joinCross,
     reroot,
     resolve,
+    joinNames,
 
     dir,
-    ext,
     prefixGet,
     name,
-    joinNames,
     withoutExt,
     changeExt,
+    ext,
 
     relative,
 
     common,
-
-    begins,
-    ends,
 
   },
 

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -1680,6 +1680,177 @@ function isRelative( test )
 
 //
 
+function isGlobal( test )
+{
+
+  // Not global paths
+
+  test.case = 'Empty';
+  var expected = false;
+  var got = _.path.isGlobal( '' );
+  test.identical( got, expected );
+
+  test.case = 'Empty';
+  var expected = false;
+  var got = _.path.isGlobal( '/' );
+  test.identical( got, expected );
+
+
+  test.case = 'Empty';
+  var expected = false;
+  var got = _.path.isGlobal( '/.' );
+  test.identical( got, expected );
+
+  test.case = 'Empty';
+  var expected = false;
+  var got = _.path.isGlobal( '///' );
+  test.identical( got, expected );
+
+  test.case = 'Empty';
+  var got = _.path.isGlobal( '.' );
+  test.identical( got, false );
+
+  test.case = 'Empty';
+  var expected = false;
+  var got = _.path.isGlobal( '/./.' );
+  test.identical( got, expected );
+
+  test.case = 'Empty';
+  var expected = false;
+  var got = _.path.isGlobal( './.' );
+  test.identical( got, expected );
+
+  test.case = 'Relative path';
+  var expected= false;
+  var got = _.path.isGlobal( 'c/work/f/' );
+  test.identical( got, expected );
+
+  test.case = 'posix path';
+  var path = '/foo/bar//baz/asdf/quux/..';
+  var expected = false;
+  var got = _.path.isGlobal( path );
+  test.identical( got, expected );
+
+  test.case = 'posix path';
+  var path = 'foo/bar//baz/asdf/quux/..//.';
+  var expected = false;
+  var got = _.path.isGlobal( path );
+  test.identical( got, expected );
+
+  test.case = 'windows path'; /* */
+  var path = 'c:/';
+  var expected = false;
+  var got = _.path.isGlobal( path );
+  test.identical( got, expected );
+
+  test.case = 'windows path'; /* */
+  var path = 'C:/temp/foo';
+  var expected = false;
+  var got = _.path.isGlobal( path );
+  test.identical( got, expected );
+
+  test.case = 'windows path'; /* */
+  var path = '/C:/temp/foo/bar/../';
+  var expected = false;
+  var got = _.path.isGlobal( path );
+  test.identical( got, expected );
+
+  // Global paths
+
+  test.case = 'Empty';
+  var got = _.path.isGlobal( '://' );
+  var expected = true;
+  test.identical( got, expected );
+
+
+  test.case = 'Empty';
+  var got = _.path.isGlobal( '/://' );
+  var expected = true;
+  test.identical( got, expected );
+
+  test.case = 'Empty';
+  var expected = true;
+  var got = _.path.isGlobal( '.:///' );
+  test.identical( got, expected );
+
+  test.case = 'Empty';
+  var expected = true;
+  var got = _.path.isGlobal( '/.://./.' );
+  test.identical( got, expected );
+
+  test.case = 'Relative path';
+  var expected= true;
+  var got = _.path.isGlobal( 'c/work/f/://' );
+  test.identical( got, expected );
+
+  test.case = 'posix path';
+  var path = '/foo/bar/://baz/asdf/quux/..';
+  var expected = true;
+  var got = _.path.isGlobal( path );
+  test.identical( got, expected );
+
+  test.case = 'posix path';
+  var path = '://foo/bar//baz/asdf/quux/..//.';
+  var expected = true;
+  var got = _.path.isGlobal( path );
+  test.identical( got, expected );
+
+  test.case = 'windows path'; /* */
+  var path = 'c://';
+  var expected = true;
+  var got = _.path.isGlobal( path );
+  test.identical( got, expected );
+
+  test.case = 'windows path'; /* */
+  var path = 'C://temp/foo';
+  var expected = true;
+  var got = _.path.isGlobal( path );
+  test.identical( got, expected );
+
+  test.case = 'windows path'; /* */
+  var path = '/C://temp/foo/bar/../';
+  var expected = true;
+  var got = _.path.isGlobal( path );
+  test.identical( got, expected );
+
+  /* */
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'No arguments';
+  test.shouldThrowError( () => _.path.isGlobal( ) );
+
+//  test.case = 'Two arguments';
+//  test.shouldThrowError( () => _.path.isGlobal( 'a', 'b' ) );
+
+  // Input is not path
+
+  test.case = 'No path - regexp';
+  test.shouldThrowError( () => _.path.isGlobal( /foo/ ) );
+
+  test.case = 'No path - number';
+  test.shouldThrowError( () => _.path.isGlobal( 3 ) );
+
+  test.case = 'No path - array';
+  test.shouldThrowError( () => _.path.isGlobal( [ '/C/', 'work/f' ] ) );
+
+  test.case = 'No path - object';
+  test.shouldThrowError( () => _.path.isGlobal( { Path : 'C:/foo/baz/bar' } ) );
+
+  test.case = 'No path - undefined';
+  test.shouldThrowError( () => _.path.isGlobal( undefined ) );
+
+  test.case = 'No path - null';
+  test.shouldThrowError( () => _.path.isGlobal( null ) );
+
+  test.case = 'No path - NaN';
+  test.shouldThrowError( () => _.path.isGlobal( NaN ) );
+
+}
+
+//
+
 function isRoot( test )
 {
 
@@ -4484,6 +4655,7 @@ var Self =
     isRefined,
     isAbsolute,
     isRelative,
+    isGlobal,
     isRoot,
 
     begins,

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -10,11 +10,17 @@ if( typeof module !== 'undefined' )
   _.include( 'wTesting' );
 
   require( '../l3/Path.s' );
+  require( 'wFiles' )
 
 }
 
 var _global = _global_;
 var _ = _global_.wTools;
+var o =
+{
+  fileProvider :   _.fileProvider,
+  filter : null
+};
 
 //
 
@@ -206,6 +212,97 @@ function are( test )
   test.shouldThrowError( () => _.path.are( 'a', 'b' ) );
 
 }
+//
+
+function like( test )
+{
+
+  // Input is path
+
+  test.case = 'Empty string';
+  var expected = true;
+  var got = _.path.like( '' );
+  test.identical( got, expected );
+
+  test.case = 'Empty path';
+  var expected = true;
+  var got = _.path.like( '/' );
+  test.identical( got, expected );
+
+  test.case = 'Simple string';
+  var expected = true;
+  var got = _.path.like( 'hello' );
+  test.identical( got, expected );
+
+  test.case = 'Simple path string';
+  var expected = true;
+  var got = _.path.like( '/D/work/f' );
+  test.identical( got, expected );
+
+  test.case = 'Relative path';
+  var expected = true;
+  var got = _.path.like( '/home/user/dir1/dir2' );
+  test.identical( got, expected );
+
+  test.case = 'Absolute path';
+  var expected = true;
+  var got = _.path.like( 'C:/foo/baz/bar' );
+  test.identical( got, expected );
+
+  test.case = 'Other path';
+  var expected = true;
+  var got = _.path.like( 'c:\\foo\\' );
+  test.identical( got, expected );
+
+  // Input is not like path
+
+  test.case = 'No path - regexp';
+  var expected = false;
+  var got = _.path.like( /foo/ );
+  test.identical( got, expected );
+
+  test.case = 'No path - number';
+  var expected = false;
+  var got = _.path.like( 3 );
+  test.identical( got, expected );
+
+  test.case = 'No path - array';
+  var expected = false;
+  var got = _.path.like( [ '/C/', 'work/f' ] );
+  test.identical( got, expected );
+
+  test.case = 'No path - object';
+  var expected = false;
+  var got = _.path.like( { Path : 'C:/foo/baz/bar' } );
+  test.identical( got, expected );
+
+  test.case = 'No path - undefined';
+  var expected = false;
+  var got = _.path.like( undefined );
+  test.identical( got, expected );
+
+  test.case = 'No path - null';
+  var expected = false;
+  var got = _.path.like( null );
+  test.identical( got, expected );
+
+  test.case = 'No path - NaN';
+  var expected = false;
+  var got = _.path.like( NaN );
+  test.identical( got, expected );
+
+  /* */
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'No arguments';
+  test.shouldThrowError( () => _.path.like( ) );
+
+  test.case = 'Two arguments';
+  test.shouldThrowError( () => _.path.like( 'a', 'b' ) );
+
+}
 
 //
 
@@ -222,6 +319,198 @@ function isSafe( test )
     path7 = '/',
     path8 = '/a',
     got;
+
+  // level 0 - Always True
+
+  test.case = 'Absolute path, only 2 parts';
+
+  var got = _.path.isSafe( '/D/work/', 0 );
+  test.identical( got, true );
+
+  test.case = 'unsafe windows path';
+  var got = _.path.isSafe( path5, 0 );
+  test.identical( got, true );
+
+  test.case = 'unsafe windows path';
+  var got = _.path.isSafe( path6, 0 );
+  test.identical( got, true );
+
+  test.case = 'unsafe short path';
+  var got = _.path.isSafe( path7, 0 );
+  test.identical( got, true );
+
+  test.case = 'unsafe short path';
+  var got = _.path.isSafe( path8, 0 );
+  test.identical( got, true );
+
+  // Absolute path long
+
+  test.case = 'Absolute path 1';
+  var got = _.path.isSafe( '/D/work/f', 1 );
+  test.identical( got, true );
+
+  test.case = 'Absolute path 2';
+  var got = _.path.isSafe( '/D/work/f/g', 2 );
+  test.identical( got, true );
+
+  test.case = 'Absolute path 3';
+  var got = _.path.isSafe( '/D/work/f/g', 3 );
+  test.identical( got, true );
+
+  // Absolute path short
+
+  test.case = 'Absolute path 1';
+  var got = _.path.isSafe( '/D', 1 );
+  test.identical( got, false );
+
+  test.case = 'Absolute path 2';
+  var got = _.path.isSafe( '/D', 2 );
+  test.identical( got, false );
+
+  test.case = 'Absolute path 3';
+  var got = _.path.isSafe( '/D', 3 );
+  test.identical( got, false );
+
+  test.case = 'Absolute path 2';
+  var got = _.path.isSafe( '/D/work', 2 );
+  test.identical( got, false );
+
+  test.case = 'Absolute path 3';
+  var got = _.path.isSafe( '/D/work', 3 );
+  test.identical( got, false );
+
+  // No absolute path long
+
+  test.case = 'Not absolute path 1';
+  var got = _.path.isSafe( 'c/work/f/', 1 );
+  test.identical( got, true );
+
+  test.case = 'Not absolute path 2';
+  var got = _.path.isSafe( 'c/work/f/', 2 );
+  test.identical( got, true );
+
+  test.case = 'Not absolute path 3';
+  var got = _.path.isSafe( 'c/work/f/', 3 );
+  test.identical( got, true );
+
+  // No absolute path short
+
+  test.case = 'Not absolute path 1';
+  var got = _.path.isSafe( 'c/work', 1 );
+  test.identical( got, true );
+
+  test.case = 'Not absolute path 2';
+  var got = _.path.isSafe( 'c/', 2 );
+  test.identical( got, true );
+
+  test.case = 'Not absolute path 3';
+  var got = _.path.isSafe( 'c/', 3 );
+  test.identical( got, true );
+
+  if( process.platform === 'win32' )
+  {
+
+    // Absolute path short
+
+    test.case = 'Absolute path';
+    var got = _.path.isSafe( '/D/work', 1 );
+    test.identical( got, false );
+
+    test.case = 'Absolute path';
+    var got = _.path.isSafe( '/D/work', 2 );
+    test.identical( got, false );
+
+    test.case = 'Absolute path';
+    var got = _.path.isSafe( '/D/work', 3 );
+    test.identical( got, false );
+
+    test.case = 'Absolute path';
+    var got = _.path.isSafe( '/D/work/f', 2 );
+    test.identical( got, false );
+
+    test.case = 'Absolute path';
+    var got = _.path.isSafe( '/D/work/f', 3 );
+    test.identical( got, false );
+
+    // No absolute path contains 'Windows'
+
+    test.case = 'Not absolute path 1';
+    var got = _.path.isSafe( 'c/Windows/f/', 1 );
+    test.identical( got, true );
+
+    test.case = 'Not absolute path 2';
+    var got = _.path.isSafe( 'c/Windows/f/g', 2 );
+    test.identical( got, false );
+
+    test.case = 'Not absolute path 3';
+    var got = _.path.isSafe( 'c/Windows/f/g', 3 );
+    test.identical( got, false );
+
+    test.case = 'Absolute path 3';
+    var got = _.path.isSafe( 'c:/Windows/f/g', 3 );
+    test.identical( got, true );
+
+    // No absolute path contains 'Program Files'
+
+    test.case = 'Not absolute path 1';
+    var got = _.path.isSafe( 'c/Program Files/f/', 1 );
+    test.identical( got, true );
+
+    test.case = 'Not absolute path 2';
+    var got = _.path.isSafe( 'c/Program Files/f/g', 2 );
+    test.identical( got, false );
+
+    test.case = 'Not absolute path 3';
+    var got = _.path.isSafe( 'c/Program Files/f/g', 3 );
+    test.identical( got, false );
+
+    test.case = 'Absolute path 3';
+    var got = _.path.isSafe( 'c:/Program Files/f/g', 3 );
+    test.identical( got, true );
+
+  }
+
+  // No absolute path contains RegExp characters
+
+  test.case = 'Not absolute path 1';
+  var got = _.path.isSafe( '.c/Program/.f/', 1 );
+  test.identical( got, true );
+
+  test.case = 'Not absolute path 2';
+  var got = _.path.isSafe( '.c/Program/.f/g', 2 );
+  test.identical( got, false );
+
+  test.case = 'Not absolute path 3';
+  var got = _.path.isSafe( '.c/Program/.f/g', 3 );
+  test.identical( got, false );
+
+  test.case = 'Absolute path 3';
+  var got = _.path.isSafe( 'c:/Program/.f/g', 3 );
+  test.identical( got, true );
+
+  // No absolute path contains RegExp node_modules
+
+  test.case = 'Not absolute path 1';
+  var got = _.path.isSafe( 'node_modules/Program/f/', 1 );
+  test.identical( got, true );
+
+  test.case = 'Not absolute path 2';
+  var got = _.path.isSafe( 'node_modules/Program/f/', 2 );
+  test.identical( got, true );
+
+  test.case = 'Not absolute path 3';
+  var got = _.path.isSafe( 'node_modules/Program/f/', 3 );
+  test.identical( got, false );
+
+  test.case = 'Not absolute path 3';
+  var got = _.path.isSafe( '/Program/node_modules/', 3 );
+  test.identical( got, false );
+
+  test.case = 'Absolute path 3';
+  var got = _.path.isSafe( 'c:/Program/node_modules/g', 3 );
+  test.identical( got, true );
+
+  //
 
   test.case = 'safe windows path, level:2';
   var got = _.path.isSafe( '/D/work/f', 2 );
@@ -314,13 +603,25 @@ function isSafe( test )
     _.path.isSafe( );
   });
 
+  test.case = 'Too many arguments';
+  test.shouldThrowErrorSync( function( )
+  {
+    _.path.isSafe( '/a/b', 2, '/a/b' );
+  });
+
   test.case = 'argument is not string';
   test.shouldThrowErrorSync( function( )
   {
     _.path.isSafe( null );
   });
 
-  test.case = 'too macny arguments';
+  test.case = 'Wrong first argument';
+  test.shouldThrowErrorSync( function( )
+  {
+    _.path.isSafe( null, 1 );
+  });
+
+  test.case = 'Wrong second argument';
   test.shouldThrowErrorSync( function( )
   {
     _.path.isSafe( '/a/b','/a/b' );
@@ -3498,6 +3799,7 @@ var Self =
 
     is,
     are,
+    like,
     isSafe,
     isRefined,
     isRoot,

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -700,68 +700,6 @@ function isRefined( test )
 
 //
 
-function isGlob( test )
-{
-
-  test.case = 'this is not glob';
-
-  test.is( !_.path.isGlob( '!a.js' ) );
-  test.is( !_.path.isGlob( '^a.js' ) );
-  test.is( !_.path.isGlob( '+a.js' ) );
-  test.is( !_.path.isGlob( '!' ) );
-  test.is( !_.path.isGlob( '^' ) );
-  test.is( !_.path.isGlob( '+' ) );
-
-  /**/
-
-  test.case = 'this is glob';
-
-  test.is( _.path.isGlob( '?' ) );
-  test.is( _.path.isGlob( '*' ) );
-  test.is( _.path.isGlob( '**' ) );
-
-  test.is( _.path.isGlob( '?c.js' ) );
-  test.is( _.path.isGlob( '*.js' ) );
-  test.is( _.path.isGlob( '**/a.js' ) );
-
-  test.is( _.path.isGlob( 'dir?c/a.js' ) );
-  test.is( _.path.isGlob( 'dir/*.js' ) );
-  test.is( _.path.isGlob( 'dir/**.js' ) );
-  test.is( _.path.isGlob( 'dir/**/a.js' ) );
-
-  test.is( _.path.isGlob( '/dir?c/a.js' ) );
-  test.is( _.path.isGlob( '/dir/*.js' ) );
-  test.is( _.path.isGlob( '/dir/**.js' ) );
-  test.is( _.path.isGlob( '/dir/**/a.js' ) );
-
-  test.is( _.path.isGlob( '[a-c]' ) );
-  test.is( _.path.isGlob( '{a,c}' ) );
-  test.is( _.path.isGlob( '(a|b)' ) );
-
-  test.is( _.path.isGlob( '(ab)' ) );
-  test.is( _.path.isGlob( '@(ab)' ) );
-  test.is( _.path.isGlob( '!(ab)' ) );
-  test.is( _.path.isGlob( '?(ab)' ) );
-  test.is( _.path.isGlob( '*(ab)' ) );
-  test.is( _.path.isGlob( '+(ab)' ) );
-
-  test.is( _.path.isGlob( 'dir/[a-c].js' ) );
-  test.is( _.path.isGlob( 'dir/{a,c}.js' ) );
-  test.is( _.path.isGlob( 'dir/(a|b).js' ) );
-
-  test.is( _.path.isGlob( 'dir/(ab).js' ) );
-  test.is( _.path.isGlob( 'dir/@(ab).js' ) );
-  test.is( _.path.isGlob( 'dir/!(ab).js' ) );
-  test.is( _.path.isGlob( 'dir/?(ab).js' ) );
-  test.is( _.path.isGlob( 'dir/*(ab).js' ) );
-  test.is( _.path.isGlob( 'dir/+(ab).js' ) );
-
-  test.is( _.path.isGlob( '/index/**' ) );
-
-}
-
-//
-
 function isRoot( test )
 {
 
@@ -3562,7 +3500,6 @@ var Self =
     are,
     isSafe,
     isRefined,
-    isGlob,
     isRoot,
 
     begins,

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -631,6 +631,292 @@ function isSafe( test )
 
 //
 
+function isNormalized( test )
+{
+
+  var got;
+
+  test.case = 'posix path'; /* */
+
+  // Not normalized
+
+  var path = '/foo/bar//baz/asdf/quux/..';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '/foo/bar//baz/asdf/quux/../';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = 'foo/bar//baz/asdf/quux/..//.';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  // Normalized
+
+  var path = '/foo/bar//baz/asdf';
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = _.path.normalize( '/foo/bar//baz/asdf/quux/../' );
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = _.path.normalize( 'foo/bar//baz/asdf/quux/..//.' );
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  test.case = 'windows path'; /* */
+
+  //Not normalized
+
+  var path = '/C:\\temp\\\\foo\\bar\\..\\';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '\\C:\\temp\\\\foo\\bar\\..\\';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = 'C:\\temp\\\\foo\\bar\\..\\..\\';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  // Normalized
+
+  var path = _.path.normalize( '/C:\\temp\\\\foo\\bar\\..\\' );
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '/C:/temp//foo';
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = _.path.normalize( 'C:\\temp\\\\foo\\bar\\..\\..\\' );
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  test.case = 'empty path'; /* */
+
+  var path = '';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '.';
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '/';
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '///';
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '/./.';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = './.';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  test.case = 'path with "." in the middle'; /* */
+
+  var path = 'foo/./bar/baz';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '/foo/././bar/././baz/';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '/foo/.x./baz';
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  test.case = 'path with "." in the beginning'; /* */
+
+  var path = './foo/bar';
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '.\\foo\\bar';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '././foo/bar/';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '/.//.//foo/bar/';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '.x./foo/bar';
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  test.case = 'path with "." in the end'; /* */
+
+  var path = 'foo/.bar.';
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = 'foo/bar/./.';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '/foo/baz/.x./';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  test.case = 'path with ".." in the middle'; /* */
+
+  var path = 'foo/../bar/baz';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '/foo/../../bar/../../baz/';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = _.path.normalize( '/foo/../../bar/../../baz/' );
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '/../../baz';
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  test.case = 'path with ".." in the beginning'; /* */
+
+  var path = '../../foo/bar';
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '..//..//foo/bar/';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '..x../foo/bar';
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  test.case = 'path with ".." in the end'; /* */
+
+  var path = 'foo/..bar..';
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = 'foo/bar/..';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = 'foo/bar/../../../..';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  test.case = 'path with ".." and "." combined'; /* */
+
+  var path = '/abc/./.././a/b';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = '/a/b/abc/./../.';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = './../.';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  var path = _.path.normalize( '/a/b/abc/./../.' );
+  var expected = true;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
+  /* */
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'No arguments';
+  test.shouldThrowError( () => _.path.normalize( ) );
+
+  test.case = 'Two arguments';
+  test.shouldThrowError( () => _.path.normalize( 'a', 'b' ) );
+
+  // Input is not path
+
+  test.case = 'No path - regexp';
+  test.shouldThrowError( () => _.path.normalize( /foo/ ) );
+
+  test.case = 'No path - number';
+  test.shouldThrowError( () => _.path.normalize( 3 ) );
+
+  test.case = 'No path - array';
+  test.shouldThrowError( () => _.path.normalize( [ '/C/', 'work/f' ] ) );
+
+  test.case = 'No path - object';
+  test.shouldThrowError( () => _.path.normalize( { Path : 'C:/foo/baz/bar' } ) );
+
+  test.case = 'No path - undefined';
+  test.shouldThrowError( () => _.path.normalize( undefined ) );
+
+  test.case = 'No path - null';
+  test.shouldThrowError( () => _.path.normalize( null ) );
+
+  test.case = 'No path - NaN';
+  test.shouldThrowError( () => _.path.normalize( NaN ) );
+
+}
+
+//
+
 function isRefined( test )
 {
   test.case = 'posix path, not refined'; /* */
@@ -3801,6 +4087,7 @@ var Self =
     are,
     like,
     isSafe,
+    isNormalized,
     isRefined,
     isRoot,
 

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -536,14 +536,6 @@ function isSafe( test )
   var got = _.path.isSafe( path4 );
   test.identical( got, true );
 
-  test.case = 'unsafe windows path';
-  var got = _.path.isSafe( path5 );
-  test.identical( got, false );
-
-  test.case = 'unsafe windows path';
-  var got = _.path.isSafe( path6 );
-  test.identical( got, false );
-
   test.case = 'unsafe short path';
   var got = _.path.isSafe( path7 );
   test.identical( got, false );
@@ -572,6 +564,14 @@ function isSafe( test )
 
   if( process.platform === 'win32' )
   {
+
+    test.case = 'unsafe windows path';
+    var got = _.path.isSafe( path5 );
+    test.identical( got, false );
+
+    test.case = 'unsafe windows path';
+    var got = _.path.isSafe( path6 );
+    test.identical( got, false );
 
     var got = _.path.isSafe( '/c/Windows' );
     test.identical( got, false );

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -691,6 +691,11 @@ function isNormalized( test )
   var got = _.path.isNormalized( path );
   test.identical( got, expected );
 
+  var path = 'c://temp/foo/bar/';
+  var expected = false;
+  var got = _.path.isNormalized( path );
+  test.identical( got, expected );
+
   // Normalized
 
   var path = _.path.normalize( '/C:\\temp\\\\foo\\bar\\..\\' );
@@ -1317,6 +1322,179 @@ function isRefined( test )
 
   test.case = 'No path - NaN';
   test.shouldThrowError( () => _.path.isRefined( NaN ) );
+
+}
+
+//
+
+function isAbsolute( test )
+{
+
+  // Absolute path
+
+  test.case = 'Absolute path';
+  var got = _.path.isAbsolute( '/D' );
+  test.identical( got, true );
+
+  test.case = 'Absolute path';
+  var got = _.path.isAbsolute( '/D/' );
+  test.identical( got, true );
+
+  test.case = 'Absolute path';
+  var got = _.path.isAbsolute( '/D/work' );
+  test.identical( got, true );
+
+  test.case = 'Absolute path';
+  var got = _.path.isAbsolute( '/D/work/f' );
+  test.identical( got, true );
+
+  test.case = 'Absolute path';
+  var got = _.path.isAbsolute( '/D/work/f/' );
+  test.identical( got, true );
+
+  // No absolute path
+
+  test.case = 'Not absolute path';
+  var got = _.path.isAbsolute( 'c' );
+  test.identical( got, false );
+
+  test.case = 'Not absolute path';
+  var got = _.path.isAbsolute( 'c/' );
+  test.identical( got, false );
+
+  test.case = 'Not absolute path';
+  var got = _.path.isAbsolute( 'c/work' );
+  test.identical( got, false );
+
+  test.case = 'Not absolute path';
+  var got = _.path.isAbsolute( 'c/work/' );
+  test.identical( got, false );
+
+  test.case = 'posix path'; /* */
+
+  var path = '/foo/bar//baz/asdf/quux/..';
+  var expected = true;
+  var got = _.path.isAbsolute( path );
+  test.identical( got, expected );
+
+  var path = 'foo/bar//baz/asdf/quux/..//.';
+  var expected = false;
+  var got = _.path.isAbsolute( path );
+  test.identical( got, expected );
+
+  test.case = 'windows path'; /* */
+
+  //Not normalized
+
+  var path = '/C:/temp/foo/bar/../';
+  var expected = true;
+  var got = _.path.isAbsolute( path );
+  test.identical( got, expected );
+
+  var path = 'C:/temp/foo/bar/../';
+  var expected = false;
+  var got = _.path.isAbsolute( path );
+  test.identical( got, expected );
+
+  var path = 'c://temp/foo/bar/';
+  var expected = false;
+  var got = _.path.isAbsolute( path );
+  test.identical( got, expected );
+
+  // Normalized
+
+  var path = _.path.normalize( '/C:/temp/foo/bar/../' );
+  var expected = true;
+  var got = _.path.isAbsolute( path );
+  test.identical( got, expected );
+
+  var path = _.path.normalize( 'C:/temp/foo/bar/../' );
+  var expected = true;
+  var got = _.path.isAbsolute( path );
+  test.identical( got, expected );
+
+  var path = _.path.normalize( 'c://temp/foo/bar/' );
+  var expected = true;
+  var got = _.path.isAbsolute( path );
+  test.identical( got, expected );
+
+  test.case = 'empty path'; /* */
+
+  var path = '';
+  var expected = false;
+  var got = _.path.isAbsolute( path );
+  test.identical( got, expected );
+
+  var path = '.';
+  var expected = false;
+  var got = _.path.isAbsolute( path );
+  test.identical( got, expected );
+
+  var path = '/';
+  var expected = true;
+  var got = _.path.isAbsolute( path );
+  test.identical( got, expected );
+
+  var path = '///';
+  var expected = true;
+  var got = _.path.isAbsolute( path );
+  test.identical( got, expected );
+
+  var path = '/./.';
+  var expected = true;
+  var got = _.path.isAbsolute( path );
+  test.identical( got, expected );
+
+  var path = './.';
+  var expected = false;
+  var got = _.path.isAbsolute( path );
+  test.identical( got, expected );
+
+
+  /* */
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'No arguments';
+  test.shouldThrowError( () => _.path.isAbsolute( ) );
+
+  test.case = 'Two arguments';
+  test.shouldThrowError( () => _.path.isAbsolute( 'a', 'b' ) );
+
+  // Input is not path
+
+  test.case = 'No path - regexp';
+  test.shouldThrowError( () => _.path.isAbsolute( /foo/ ) );
+
+  test.case = 'No path - number';
+  test.shouldThrowError( () => _.path.isAbsolute( 3 ) );
+
+  test.case = 'No path - array';
+  test.shouldThrowError( () => _.path.isAbsolute( [ '/C/', 'work/f' ] ) );
+
+  test.case = 'No path - object';
+  test.shouldThrowError( () => _.path.isAbsolute( { Path : 'C:/foo/baz/bar' } ) );
+
+  test.case = 'No path - undefined';
+  test.shouldThrowError( () => _.path.isAbsolute( undefined ) );
+
+  test.case = 'No path - null';
+  test.shouldThrowError( () => _.path.isAbsolute( null ) );
+
+  test.case = 'No path - NaN';
+  test.shouldThrowError( () => _.path.isAbsolute( NaN ) );
+
+  // Input is not Normalized
+
+  test.case = '\\ in the beggining';
+  test.shouldThrowError( () => _.path.isAbsolute( '\\C:/foo/baz/bar' ) );
+
+  test.case = '\\ in the middle';
+  test.shouldThrowError( () => _.path.isAbsolute( 'C:/foo\\baz\\bar' ) );
+
+  test.case = '\\ in the end';
+  test.shouldThrowError( () => _.path.isAbsolute( 'C:/foo/baz/bar\\' ) );
 
 }
 
@@ -4124,6 +4302,7 @@ var Self =
     isSafe,
     isNormalized,
     isRefined,
+    isAbsolute,
     isRoot,
 
     begins,

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -412,23 +412,23 @@ function isSafe( test )
 
     // Absolute path short
 
-    test.case = 'Absolute path';
+    test.case = 'Absolute path 1';
     var got = _.path.isSafe( '/D/work', 1 );
     test.identical( got, false );
 
-    test.case = 'Absolute path';
+    test.case = 'Absolute path 2';
     var got = _.path.isSafe( '/D/work', 2 );
     test.identical( got, false );
 
-    test.case = 'Absolute path';
+    test.case = 'Absolute path 3';
     var got = _.path.isSafe( '/D/work', 3 );
     test.identical( got, false );
 
-    test.case = 'Absolute path';
+    test.case = 'Absolute path 2';
     var got = _.path.isSafe( '/D/work/f', 2 );
     test.identical( got, false );
 
-    test.case = 'Absolute path';
+    test.case = 'Absolute path 3';
     var got = _.path.isSafe( '/D/work/f', 3 );
     test.identical( got, false );
 
@@ -537,24 +537,19 @@ function isSafe( test )
   test.identical( got, true );
 
   test.case = 'unsafe short path';
+
   var got = _.path.isSafe( path7 );
   test.identical( got, false );
 
-  test.case = 'unsafe short path';
   var got = _.path.isSafe( path8 );
   test.identical( got, false );
 
-  /* - */
-
-  test.case = 'unsafe short path';
   var got = _.path.isSafe( '/dir1/dir2', 2 );
   test.identical( got, false );
 
-  test.case = 'unsafe short path';
   var got = _.path.isSafe( '/dir1/dir2', 1 );
   test.identical( got, true );
 
-  test.case = 'unsafe short path';
   var got = _.path.isSafe( '/dir1', 1 );
   test.identical( got, false );
 
@@ -1333,40 +1328,35 @@ function isAbsolute( test )
   // Absolute path
 
   test.case = 'Absolute path';
+
   var got = _.path.isAbsolute( '/D' );
   test.identical( got, true );
 
-  test.case = 'Absolute path';
   var got = _.path.isAbsolute( '/D/' );
   test.identical( got, true );
 
-  test.case = 'Absolute path';
   var got = _.path.isAbsolute( '/D/work' );
   test.identical( got, true );
 
-  test.case = 'Absolute path';
   var got = _.path.isAbsolute( '/D/work/f' );
   test.identical( got, true );
 
-  test.case = 'Absolute path';
   var got = _.path.isAbsolute( '/D/work/f/' );
   test.identical( got, true );
 
   // No absolute path
 
   test.case = 'Not absolute path';
+
   var got = _.path.isAbsolute( 'c' );
   test.identical( got, false );
 
-  test.case = 'Not absolute path';
   var got = _.path.isAbsolute( 'c/' );
   test.identical( got, false );
 
-  test.case = 'Not absolute path';
   var got = _.path.isAbsolute( 'c/work' );
   test.identical( got, false );
 
-  test.case = 'Not absolute path';
   var got = _.path.isAbsolute( 'c/work/' );
   test.identical( got, false );
 
@@ -1505,44 +1495,38 @@ function isRelative( test )
   // Absolute path
 
   test.case = 'Absolute path';
+
   var got = _.path.isRelative( '/D' );
   test.identical( got, false );
 
-  test.case = 'Absolute path';
   var got = _.path.isRelative( '/D/' );
   test.identical( got, false );
 
-  test.case = 'Absolute path';
   var got = _.path.isRelative( '/D/work' );
   test.identical( got, false );
 
-  test.case = 'Absolute path';
   var got = _.path.isRelative( '/D/work/f' );
   test.identical( got, false );
 
-  test.case = 'Absolute path';
   var got = _.path.isRelative( '/D/work/f/' );
   test.identical( got, false );
 
   // Relative path
 
   test.case = 'Relative path';
+
   var got = _.path.isRelative( 'c' );
   test.identical( got, true );
 
-  test.case = 'Relative path';
   var got = _.path.isRelative( 'c/' );
   test.identical( got, true );
 
-  test.case = 'Relative path';
   var got = _.path.isRelative( 'c/work' );
   test.identical( got, true );
 
-  test.case = 'Relative path';
   var got = _.path.isRelative( 'c/work/' );
   test.identical( got, true );
 
-  test.case = 'Relative path';
   var got = _.path.isRelative( 'c/work/f/' );
   test.identical( got, true );
 
@@ -1686,36 +1670,31 @@ function isGlobal( test )
   // Not global paths
 
   test.case = 'Empty';
+
   var expected = false;
   var got = _.path.isGlobal( '' );
   test.identical( got, expected );
 
-  test.case = 'Empty';
   var expected = false;
   var got = _.path.isGlobal( '/' );
   test.identical( got, expected );
 
-
-  test.case = 'Empty';
   var expected = false;
   var got = _.path.isGlobal( '/.' );
   test.identical( got, expected );
 
-  test.case = 'Empty';
   var expected = false;
   var got = _.path.isGlobal( '///' );
   test.identical( got, expected );
 
-  test.case = 'Empty';
+  var expected = false;
   var got = _.path.isGlobal( '.' );
-  test.identical( got, false );
+  test.identical( got, expected );
 
-  test.case = 'Empty';
   var expected = false;
   var got = _.path.isGlobal( '/./.' );
   test.identical( got, expected );
 
-  test.case = 'Empty';
   var expected = false;
   var got = _.path.isGlobal( './.' );
   test.identical( got, expected );
@@ -1726,24 +1705,24 @@ function isGlobal( test )
   test.identical( got, expected );
 
   test.case = 'posix path';
+
   var path = '/foo/bar//baz/asdf/quux/..';
   var expected = false;
   var got = _.path.isGlobal( path );
   test.identical( got, expected );
 
-  test.case = 'posix path';
   var path = 'foo/bar//baz/asdf/quux/..//.';
   var expected = false;
   var got = _.path.isGlobal( path );
   test.identical( got, expected );
 
   test.case = 'windows path'; /* */
+
   var path = 'c:/';
   var expected = false;
   var got = _.path.isGlobal( path );
   test.identical( got, expected );
 
-  test.case = 'windows path'; /* */
   var path = 'C:/temp/foo';
   var expected = false;
   var got = _.path.isGlobal( path );
@@ -1758,22 +1737,19 @@ function isGlobal( test )
   // Global paths
 
   test.case = 'Empty';
+
   var got = _.path.isGlobal( '://' );
   var expected = true;
   test.identical( got, expected );
 
-
-  test.case = 'Empty';
   var got = _.path.isGlobal( '/://' );
   var expected = true;
   test.identical( got, expected );
 
-  test.case = 'Empty';
   var expected = true;
   var got = _.path.isGlobal( '.:///' );
   test.identical( got, expected );
 
-  test.case = 'Empty';
   var expected = true;
   var got = _.path.isGlobal( '/.://./.' );
   test.identical( got, expected );
@@ -1784,30 +1760,29 @@ function isGlobal( test )
   test.identical( got, expected );
 
   test.case = 'posix path';
+
   var path = '/foo/bar/://baz/asdf/quux/..';
   var expected = true;
   var got = _.path.isGlobal( path );
   test.identical( got, expected );
 
-  test.case = 'posix path';
   var path = '://foo/bar//baz/asdf/quux/..//.';
   var expected = true;
   var got = _.path.isGlobal( path );
   test.identical( got, expected );
 
   test.case = 'windows path'; /* */
+
   var path = 'c://';
   var expected = true;
   var got = _.path.isGlobal( path );
   test.identical( got, expected );
 
-  test.case = 'windows path'; /* */
   var path = 'C://temp/foo';
   var expected = true;
   var got = _.path.isGlobal( path );
   test.identical( got, expected );
 
-  test.case = 'windows path'; /* */
   var path = '/C://temp/foo/bar/../';
   var expected = true;
   var got = _.path.isGlobal( path );
@@ -1854,25 +1829,17 @@ function isGlobal( test )
 function isRoot( test )
 {
 
-  test.case = 'trivial';
-
-  var path = '/src/a1';
-  var got = _.path.isRoot( path );
-  test.identical( got, false );
-
-  var path = '.';
-  var got = _.path.isRoot( path );
-  test.identical( got, false );
-
-  var path = '';
-  var got = _.path.isRoot( path );
-  test.identical( got, false );
+  test.case = 'Is root';
 
   var path = '/';
   var got = _.path.isRoot( path );
   test.identical( got, true );
 
   var path = '/.';
+  var got = _.path.isRoot( path );
+  test.identical( got, true );
+
+  var path = '/./';
   var got = _.path.isRoot( path );
   test.identical( got, true );
 
@@ -1883,6 +1850,78 @@ function isRoot( test )
   var path = '/x/..';
   var got = _.path.isRoot( path );
   test.identical( got, true );
+
+  var path = '/x/y/../..';
+  var got = _.path.isRoot( path );
+  test.identical( got, true );
+
+  test.case = 'Is not root';
+
+  var path = '';
+  var got = _.path.isRoot( path );
+  test.identical( got, false );
+
+  var path = '.';
+  var got = _.path.isRoot( path );
+  test.identical( got, false );
+
+  var path = './';
+  var got = _.path.isRoot( path );
+  test.identical( got, false );
+
+  var path = '/c';
+  var got = _.path.isRoot( path );
+  test.identical( got, false );
+
+  var path = '/src/a1';
+  var got = _.path.isRoot( path );
+  test.identical( got, false );
+
+  var path = 'c:/src/a1';
+  var got = _.path.isRoot( path );
+  test.identical( got, false );
+
+  var path = '/C://src/a1';
+  var got = _.path.isRoot( path );
+  test.identical( got, false );
+
+  var path = 'foo/bar//baz/asdf/quux/..//.';
+  var got = _.path.isRoot( path );
+  test.identical( got, false );
+
+  /* */
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'No arguments';
+  test.shouldThrowError( () => _.path.isRoot( ) );
+
+  test.case = 'Two arguments';
+  test.shouldThrowError( () => _.path.isRoot( 'a', 'b' ) );
+
+  // Input is not path
+
+  test.case = 'No path - regexp';
+  test.shouldThrowError( () => _.path.isRoot( /foo/ ) );
+
+  test.case = 'No path - number';
+  test.shouldThrowError( () => _.path.isGlobal( 3 ) );
+
+  test.case = 'No path - array';
+  test.shouldThrowError( () => _.path.isRoot( [ '/C/', 'work/f' ] ) );
+
+  test.case = 'No path - object';
+  test.shouldThrowError( () => _.path.isRoot( { Path : 'C:/foo/baz/bar' } ) );
+
+  test.case = 'No path - undefined';
+  test.shouldThrowError( () => _.path.isRoot( undefined ) );
+
+  test.case = 'No path - null';
+  test.shouldThrowError( () => _.path.isRoot( null ) );
+
+  test.case = 'No path - NaN';
+  test.shouldThrowError( () => _.path.isRoot( NaN ) );
 
 }
 

--- a/proto/dwtools/abase/l3.test/Path.test.s
+++ b/proto/dwtools/abase/l3.test/Path.test.s
@@ -1450,7 +1450,6 @@ function isAbsolute( test )
   var got = _.path.isAbsolute( path );
   test.identical( got, expected );
 
-
   /* */
 
   if( !Config.debug )
@@ -1495,6 +1494,187 @@ function isAbsolute( test )
 
   test.case = '\\ in the end';
   test.shouldThrowError( () => _.path.isAbsolute( 'C:/foo/baz/bar\\' ) );
+
+}
+
+//
+
+function isRelative( test )
+{
+
+  // Absolute path
+
+  test.case = 'Absolute path';
+  var got = _.path.isRelative( '/D' );
+  test.identical( got, false );
+
+  test.case = 'Absolute path';
+  var got = _.path.isRelative( '/D/' );
+  test.identical( got, false );
+
+  test.case = 'Absolute path';
+  var got = _.path.isRelative( '/D/work' );
+  test.identical( got, false );
+
+  test.case = 'Absolute path';
+  var got = _.path.isRelative( '/D/work/f' );
+  test.identical( got, false );
+
+  test.case = 'Absolute path';
+  var got = _.path.isRelative( '/D/work/f/' );
+  test.identical( got, false );
+
+  // Relative path
+
+  test.case = 'Relative path';
+  var got = _.path.isRelative( 'c' );
+  test.identical( got, true );
+
+  test.case = 'Relative path';
+  var got = _.path.isRelative( 'c/' );
+  test.identical( got, true );
+
+  test.case = 'Relative path';
+  var got = _.path.isRelative( 'c/work' );
+  test.identical( got, true );
+
+  test.case = 'Relative path';
+  var got = _.path.isRelative( 'c/work/' );
+  test.identical( got, true );
+
+  test.case = 'Relative path';
+  var got = _.path.isRelative( 'c/work/f/' );
+  test.identical( got, true );
+
+  test.case = 'posix path'; /* */
+
+  var path = '/foo/bar//baz/asdf/quux/..';
+  var expected = false;
+  var got = _.path.isRelative( path );
+  test.identical( got, expected );
+
+  var path = 'foo/bar//baz/asdf/quux/..//.';
+  var expected = true;
+  var got = _.path.isRelative( path );
+  test.identical( got, expected );
+
+  test.case = 'windows path'; /* */
+
+  //Not normalized
+
+  var path = '/C:/temp/foo/bar/../';
+  var expected = false;
+  var got = _.path.isRelative( path );
+  test.identical( got, expected );
+
+  var path = 'C:/temp/foo/bar/../';
+  var expected = true;
+  var got = _.path.isRelative( path );
+  test.identical( got, expected );
+
+  var path = 'c://temp/foo/bar/';
+  var expected = true;
+  var got = _.path.isRelative( path );
+  test.identical( got, expected );
+
+  // Normalized
+
+  var path = _.path.normalize( '/C:/temp/foo/bar/../' );
+  var expected = false;
+  var got = _.path.isRelative( path );
+  test.identical( got, expected );
+
+  var path = _.path.normalize( 'C:/temp/foo/bar/../' );
+  var expected = false;
+  var got = _.path.isRelative( path );
+  test.identical( got, expected );
+
+  var path = _.path.normalize( 'c://temp/foo/bar/' );
+  var expected = false;
+  var got = _.path.isRelative( path );
+  test.identical( got, expected );
+
+  var path = _.path.normalize( 'c/temp/foo/bar/' );
+  var expected = true;
+  var got = _.path.isRelative( path );
+  test.identical( got, expected );
+
+  test.case = 'empty path'; /* */
+
+  var path = '';
+  var expected = true;
+  var got = _.path.isRelative( path );
+  test.identical( got, expected );
+
+  var path = '.';
+  var expected = true;
+  var got = _.path.isRelative( path );
+  test.identical( got, expected );
+
+  var path = '/';
+  var expected = false;
+  var got = _.path.isRelative( path );
+  test.identical( got, expected );
+
+  var path = '///';
+  var expected = false;
+  var got = _.path.isRelative( path );
+  test.identical( got, expected );
+
+  var path = '/./.';
+  var expected = false;
+  var got = _.path.isRelative( path );
+  test.identical( got, expected );
+
+  var path = './.';
+  var expected = true;
+  var got = _.path.isRelative( path );
+  test.identical( got, expected );
+
+  /* */
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'No arguments';
+  test.shouldThrowError( () => _.path.isRelative( ) );
+
+  test.case = 'Two arguments';
+  test.shouldThrowError( () => _.path.isRelative( 'a', 'b' ) );
+
+  // Input is not path
+
+  test.case = 'No path - regexp';
+  test.shouldThrowError( () => _.path.isRelative( /foo/ ) );
+
+  test.case = 'No path - number';
+  test.shouldThrowError( () => _.path.isRelative( 3 ) );
+
+  test.case = 'No path - array';
+  test.shouldThrowError( () => _.path.isRelative( [ '/C/', 'work/f' ] ) );
+
+  test.case = 'No path - object';
+  test.shouldThrowError( () => _.path.isRelative( { Path : 'C:/foo/baz/bar' } ) );
+
+  test.case = 'No path - undefined';
+  test.shouldThrowError( () => _.path.isRelative( undefined ) );
+
+  test.case = 'No path - null';
+  test.shouldThrowError( () => _.path.isRelative( null ) );
+
+  test.case = 'No path - NaN';
+  test.shouldThrowError( () => _.path.isRelative( NaN ) );
+
+  // Input is not Normalized
+
+  test.case = '\\ in the beggining';
+  test.shouldThrowError( () => _.path.isRelative( '\\C:/foo/baz/bar' ) );
+
+  test.case = '\\ in the middle';
+  test.shouldThrowError( () => _.path.isRelative( 'C:/foo\\baz\\bar' ) );
+
+  test.case = '\\ in the end';
+  test.shouldThrowError( () => _.path.isRelative( 'C:/foo/baz/bar\\' ) );
 
 }
 
@@ -4303,6 +4483,7 @@ var Self =
     isNormalized,
     isRefined,
     isAbsolute,
+    isRelative,
     isRoot,
 
     begins,

--- a/proto/dwtools/abase/l3/Path.s
+++ b/proto/dwtools/abase/l3/Path.s
@@ -258,7 +258,7 @@ function like( path )
 function isSafe( filePath, level )
 {
   filePath = this.normalize( filePath );
-
+  
   if( level === undefined )
   level = 1;
 

--- a/proto/dwtools/abase/l3/Path.s
+++ b/proto/dwtools/abase/l3/Path.s
@@ -422,10 +422,12 @@ function begins( srcPath, beginPath )
 function ends( srcPath, endPath )
 {
   endPath = this.undot( endPath );
+  logger.log( 'END', endPath, this._upStr , this._hereStr  )
   if( !_.strEnds( srcPath, endPath ) )
   return false;
 
   let begin = _.strRemoveEnd( srcPath, endPath );
+  logger.log( 'BEGIN:', begin  )
   if( begin === '' || _.strEnds( begin, this._upStr ) || _.strEnds( begin, this._hereStr ) )
   return true;
 

--- a/proto/dwtools/abase/l3/Path.s
+++ b/proto/dwtools/abase/l3/Path.s
@@ -258,7 +258,7 @@ function like( path )
 function isSafe( filePath, level )
 {
   filePath = this.normalize( filePath );
-  
+
   if( level === undefined )
   level = 1;
 

--- a/proto/dwtools/abase/l3/Path.s
+++ b/proto/dwtools/abase/l3/Path.s
@@ -267,15 +267,15 @@ function isSafe( filePath, level )
 
   if( level >= 1 )
   {
-    let isAbsolute = this.isAbsolute( filePath );
-    if( isAbsolute )
+    //let isAbsolute = this.isAbsolute( filePath );
+    //if( isAbsolute )
     if( this.isAbsolute( filePath ) )
     {
       // debugger;
       let parts = filePath.split( this._upStr ).filter( ( p ) => p.trim() );
-      let number = parts.lenth;
+      //let number = parts.lenth;
       if( process.platform === 'win32' && parts.length && parts[ 0 ].length === 1 )
-      parts.splice( 0,1 )
+      parts.splice( 0,1 );
       if( parts.length <= 1 )
       return false;
       if( level >= 2 && parts.length <= 2 )

--- a/proto/dwtools/abase/l3/Path.s
+++ b/proto/dwtools/abase/l3/Path.s
@@ -356,6 +356,7 @@ function isAbsolute( path )
   _.assert( arguments.length === 1, 'Expects single argument' );
   _.assert( _.strIs( path ), 'Expects string {-path-}, but got', _.strType( path ) );
   _.assert( path.indexOf( '\\' ) === -1,'Expects normalized {-path-}, but got', path );
+//  _.assert( _.path.isNormalized( path ),'Expects normalized {-path-}, but got', path ); // Throws many errors
   return _.strBegins( path,this._upStr );
 }
 
@@ -372,6 +373,7 @@ function isRelative( path )
 
 function isGlobal( path )
 {
+  _.assert( arguments.length === 1, 'Expects single argument' );
   _.assert( _.strIs( path ), 'Expects string' );
   return _.strHas( path, '://' );
 }
@@ -396,6 +398,7 @@ function isRoot( path )
 
 function isDotted( srcPath )
 {
+  _.assert( arguments.length === 1, 'Expects single argument' );
   return _.strBegins( srcPath, this._hereStr );
 }
 
@@ -403,6 +406,7 @@ function isDotted( srcPath )
 
 function isTrailed( srcPath )
 {
+  _.assert( arguments.length === 1, 'Expects single argument' );
   if( srcPath === this._rootStr )
   return false;
   return _.strEnds( srcPath, this._upStr );
@@ -412,6 +416,9 @@ function isTrailed( srcPath )
 
 function begins( srcPath, beginPath )
 {
+  _.assert( arguments.length === 2, 'Expects two arguments' );
+  _.assert( _.strIs( srcPath ), 'Expects string {-srcPath-}, but got', _.strType( srcPath ) );
+  _.assert( _.strIs( beginPath ), 'Expects string {-beginPath-}, but got', _.strType( beginPath ) );
   if( srcPath === beginPath )
   return true;
   return _.strBegins( srcPath, this.trail( beginPath ) );
@@ -421,13 +428,13 @@ function begins( srcPath, beginPath )
 
 function ends( srcPath, endPath )
 {
+  _.assert( arguments.length === 2, 'Expects two arguments' );
   endPath = this.undot( endPath );
-  logger.log( 'END', endPath, this._upStr , this._hereStr  )
+
   if( !_.strEnds( srcPath, endPath ) )
   return false;
 
   let begin = _.strRemoveEnd( srcPath, endPath );
-  logger.log( 'BEGIN:', begin  )
   if( begin === '' || _.strEnds( begin, this._upStr ) || _.strEnds( begin, this._hereStr ) )
   return true;
 

--- a/proto/dwtools/abase/l3/Path.s
+++ b/proto/dwtools/abase/l3/Path.s
@@ -412,6 +412,24 @@ function isTrailed( srcPath )
   return _.strEnds( srcPath, this._upStr );
 }
 
+let _pathIsGlobRegexpStr = '';
+_pathIsGlobRegexpStr += '(?:[?*]+)'; /* asterix, question mark */
+_pathIsGlobRegexpStr += '|(?:([!?*@+]*)\\((.*?(?:\\|(.*?))*)\\))'; /* parentheses */
+_pathIsGlobRegexpStr += '|(?:\\[(.+?)\\])'; /* square brackets */
+_pathIsGlobRegexpStr += '|(?:\\{(.*)\\})'; /* curly brackets */
+_pathIsGlobRegexpStr += '|(?:\0)'; /* zero */
+
+let _pathIsGlobRegexp = new RegExp( _pathIsGlobRegexpStr );
+function isGlob( src )
+{
+  _.assert( arguments.length === 1, 'Expects single argument' );
+  _.assert( _.strIs( src ) );
+
+  /* let regexp = /(\*\*)|([!?*])|(\[.*\])|(\(.*\))|\{.*\}+(?![^[]*\])/g; */
+
+  return _pathIsGlobRegexp.test( src );
+}
+
 //
 
 function begins( srcPath, beginPath )
@@ -2166,6 +2184,7 @@ let Routines =
   isRoot,
   isDotted,
   isTrailed,
+  isGlob,
 
   begins,
   ends,

--- a/proto/dwtools/abase/l4.test/Paths.test.s
+++ b/proto/dwtools/abase/l4.test/Paths.test.s
@@ -411,7 +411,7 @@ function join( test )
   test.identical( got, expected );
 
   var got = _.paths.join( 'c:\\', [ '../a', './b', '..c' ] );
-  var expected = [ '/c/../a', '/c/./b', '/c/..c' ];
+  var expected = [ '/a', '/c/b', '/c/..c' ];
   test.identical( got, expected );
 
   test.case = 'join unix os paths';
@@ -425,7 +425,7 @@ function join( test )
   test.identical( got, expected );
 
   var got = _.paths.join( [ '/a', '/b', '/c' ], [ '../a', '../b', '../c' ], [ './a', './b', './c' ] );
-  var expected = [ '/a/../a/./a', '/b/../b/./b', '/c/../c/./c' ];
+  var expected = [ '/a/a', '/b/b', '/c/c' ];
   test.identical( got, expected );
 
   var got = _.paths.join( [ 'a', 'b', 'c' ], [ 'a1', 'b1', 'c1' ], [ 'a2', 'b2', 'c2' ] );
@@ -433,7 +433,7 @@ function join( test )
   test.identical( got, expected );
 
   var got = _.paths.join( [ '/a', '/b', '/c' ], [ '../a', '../b', '../c' ], [ './a', './b', './c' ] );
-  var expected = [ '/a/../a/./a', '/b/../b/./b', '/c/../c/./c' ];
+  var expected = [ '/a/a', '/b/b', '/c/c' ];
   test.identical( got, expected );
 
   var got = _.paths.join( [ '/', '/a', '//a' ], [ '//', 'a//', 'a//a' ], 'b' );
@@ -516,7 +516,7 @@ function reroot( test )
   test.identical( got, expected );
 
   var got = _.paths.reroot( '../a', [ '/b', '.c' ], './d' );
-  var expected = [ '../a/b/./d', '../a/.c/./d' ]
+  var expected = [ '../a/b/d', '../a/.c/d' ]
   test.identical( got, expected );
 
   var got = _.paths.reroot( [ '/a' , '/a' ] );
@@ -524,7 +524,7 @@ function reroot( test )
   test.identical( got, expected );
 
   var got = _.paths.reroot( '.', '/', './', [ 'a', 'b' ] );
-  var expected = [ '././a', '././b' ];
+  var expected = [ './a', './b' ];
   test.identical( got, expected );
 
   //

--- a/proto/dwtools/abase/l7.test/Glob.test.s
+++ b/proto/dwtools/abase/l7.test/Glob.test.s
@@ -18,68 +18,6 @@ var _ = _global_.wTools;
 //
 // --
 
-//
-
-function isGlob( test )
-{
-
-  test.case = 'this is not glob';
-
-  test.is( !_.path.isGlob( '!a.js' ) );
-  test.is( !_.path.isGlob( '^a.js' ) );
-  test.is( !_.path.isGlob( '+a.js' ) );
-  test.is( !_.path.isGlob( '!' ) );
-  test.is( !_.path.isGlob( '^' ) );
-  test.is( !_.path.isGlob( '+' ) );
-
-  /**/
-
-  test.case = 'this is glob';
-
-  test.is( _.path.isGlob( '?' ) );
-  test.is( _.path.isGlob( '*' ) );
-  test.is( _.path.isGlob( '**' ) );
-
-  test.is( _.path.isGlob( '?c.js' ) );
-  test.is( _.path.isGlob( '*.js' ) );
-  test.is( _.path.isGlob( '**/a.js' ) );
-
-  test.is( _.path.isGlob( 'dir?c/a.js' ) );
-  test.is( _.path.isGlob( 'dir/*.js' ) );
-  test.is( _.path.isGlob( 'dir/**.js' ) );
-  test.is( _.path.isGlob( 'dir/**/a.js' ) );
-
-  test.is( _.path.isGlob( '/dir?c/a.js' ) );
-  test.is( _.path.isGlob( '/dir/*.js' ) );
-  test.is( _.path.isGlob( '/dir/**.js' ) );
-  test.is( _.path.isGlob( '/dir/**/a.js' ) );
-
-  test.is( _.path.isGlob( '[a-c]' ) );
-  test.is( _.path.isGlob( '{a,c}' ) );
-  test.is( _.path.isGlob( '(a|b)' ) );
-
-  test.is( _.path.isGlob( '(ab)' ) );
-  test.is( _.path.isGlob( '@(ab)' ) );
-  test.is( _.path.isGlob( '!(ab)' ) );
-  test.is( _.path.isGlob( '?(ab)' ) );
-  test.is( _.path.isGlob( '*(ab)' ) );
-  test.is( _.path.isGlob( '+(ab)' ) );
-
-  test.is( _.path.isGlob( 'dir/[a-c].js' ) );
-  test.is( _.path.isGlob( 'dir/{a,c}.js' ) );
-  test.is( _.path.isGlob( 'dir/(a|b).js' ) );
-
-  test.is( _.path.isGlob( 'dir/(ab).js' ) );
-  test.is( _.path.isGlob( 'dir/@(ab).js' ) );
-  test.is( _.path.isGlob( 'dir/!(ab).js' ) );
-  test.is( _.path.isGlob( 'dir/?(ab).js' ) );
-  test.is( _.path.isGlob( 'dir/*(ab).js' ) );
-  test.is( _.path.isGlob( 'dir/+(ab).js' ) );
-
-  test.is( _.path.isGlob( '/index/**' ) );
-
-}
-
 function fromGlob( test )
 {
 
@@ -676,7 +614,6 @@ var Self =
   tests :
   {
 
-    isGlob : isGlob,
     fromGlob : fromGlob,
     globToRegexp : globToRegexp,
     relateForGlob : relateForGlob,

--- a/proto/dwtools/abase/l7.test/Glob.test.s
+++ b/proto/dwtools/abase/l7.test/Glob.test.s
@@ -112,6 +112,17 @@ function fromGlob( test )
 
 //
 
+function globToRegexp( test )
+{
+
+  var got = _.path.globToRegexp( '**/b/**' );
+  var expected = /.*\/b(?:\/.*)?$/;
+  test.identical( got, expected );
+
+}
+
+//
+
 function relateForGlob( test )
 {
 
@@ -195,17 +206,6 @@ function relateForGlob( test )
 
   var got = _.path.relateForGlob( '/src1/**', '/src1', '/src2' );
   var expected = [ '../src1/**' ];
-  test.identical( got, expected );
-
-}
-
-//
-
-function globToRegexp( test )
-{
-
-  var got = _.path.globToRegexp( '**/b/**' );
-  var expected = /.*\/b(?:\/.*)?$/;
   test.identical( got, expected );
 
 }
@@ -615,8 +615,8 @@ var Self =
   {
 
     fromGlob : fromGlob,
-    relateForGlob : relateForGlob,
     globToRegexp : globToRegexp,
+    relateForGlob : relateForGlob,
     // globRegexpsFor : globRegexpsFor,
     // globRegexpsForTerminal : globRegexpsForTerminal,
 

--- a/proto/dwtools/abase/l7.test/Glob.test.s
+++ b/proto/dwtools/abase/l7.test/Glob.test.s
@@ -18,6 +18,68 @@ var _ = _global_.wTools;
 //
 // --
 
+//
+
+function isGlob( test )
+{
+
+  test.case = 'this is not glob';
+
+  test.is( !_.path.isGlob( '!a.js' ) );
+  test.is( !_.path.isGlob( '^a.js' ) );
+  test.is( !_.path.isGlob( '+a.js' ) );
+  test.is( !_.path.isGlob( '!' ) );
+  test.is( !_.path.isGlob( '^' ) );
+  test.is( !_.path.isGlob( '+' ) );
+
+  /**/
+
+  test.case = 'this is glob';
+
+  test.is( _.path.isGlob( '?' ) );
+  test.is( _.path.isGlob( '*' ) );
+  test.is( _.path.isGlob( '**' ) );
+
+  test.is( _.path.isGlob( '?c.js' ) );
+  test.is( _.path.isGlob( '*.js' ) );
+  test.is( _.path.isGlob( '**/a.js' ) );
+
+  test.is( _.path.isGlob( 'dir?c/a.js' ) );
+  test.is( _.path.isGlob( 'dir/*.js' ) );
+  test.is( _.path.isGlob( 'dir/**.js' ) );
+  test.is( _.path.isGlob( 'dir/**/a.js' ) );
+
+  test.is( _.path.isGlob( '/dir?c/a.js' ) );
+  test.is( _.path.isGlob( '/dir/*.js' ) );
+  test.is( _.path.isGlob( '/dir/**.js' ) );
+  test.is( _.path.isGlob( '/dir/**/a.js' ) );
+
+  test.is( _.path.isGlob( '[a-c]' ) );
+  test.is( _.path.isGlob( '{a,c}' ) );
+  test.is( _.path.isGlob( '(a|b)' ) );
+
+  test.is( _.path.isGlob( '(ab)' ) );
+  test.is( _.path.isGlob( '@(ab)' ) );
+  test.is( _.path.isGlob( '!(ab)' ) );
+  test.is( _.path.isGlob( '?(ab)' ) );
+  test.is( _.path.isGlob( '*(ab)' ) );
+  test.is( _.path.isGlob( '+(ab)' ) );
+
+  test.is( _.path.isGlob( 'dir/[a-c].js' ) );
+  test.is( _.path.isGlob( 'dir/{a,c}.js' ) );
+  test.is( _.path.isGlob( 'dir/(a|b).js' ) );
+
+  test.is( _.path.isGlob( 'dir/(ab).js' ) );
+  test.is( _.path.isGlob( 'dir/@(ab).js' ) );
+  test.is( _.path.isGlob( 'dir/!(ab).js' ) );
+  test.is( _.path.isGlob( 'dir/?(ab).js' ) );
+  test.is( _.path.isGlob( 'dir/*(ab).js' ) );
+  test.is( _.path.isGlob( 'dir/+(ab).js' ) );
+
+  test.is( _.path.isGlob( '/index/**' ) );
+
+}
+
 function fromGlob( test )
 {
 
@@ -614,6 +676,7 @@ var Self =
   tests :
   {
 
+    isGlob : isGlob,
     fromGlob : fromGlob,
     globToRegexp : globToRegexp,
     relateForGlob : relateForGlob,

--- a/proto/dwtools/abase/l7/Glob.s
+++ b/proto/dwtools/abase/l7/Glob.s
@@ -64,17 +64,6 @@ _pathIsGlobRegexpStr += '|(?:\\{(.*)\\})'; /* curly brackets */
 _pathIsGlobRegexpStr += '|(?:\0)'; /* zero */
 
 let _pathIsGlobRegexp = new RegExp( _pathIsGlobRegexpStr );
-function isGlob( src )
-{
-  _.assert( arguments.length === 1, 'Expects single argument' );
-  _.assert( _.strIs( src ) );
-
-  /* let regexp = /(\*\*)|([!?*])|(\[.*\])|(\(.*\))|\{.*\}+(?![^[]*\])/g; */
-
-  return _pathIsGlobRegexp.test( src );
-}
-
-//
 
 function _fromGlob( glob )
 {
@@ -1252,8 +1241,6 @@ let Routines =
 {
 
   // glob
-
-  isGlob,
 
   _fromGlob,
   fromGlob : _.routineVectorize_functor( _fromGlob ),

--- a/sample/Sample.js
+++ b/sample/Sample.js
@@ -1,6 +1,7 @@
 
 if( typeof module !== 'undefined' )
 require( 'wPathFundamentals' );
+require( 'wFiles' )
 var _ = wTools;
 
 var file = '/a/b/c.x'

--- a/sample/SampleIs.js
+++ b/sample/SampleIs.js
@@ -16,7 +16,7 @@ console.log( 'Result', got );
 var got = _.path.isAbsolute( got );
 console.log( 'Result', got );
 
-//Q2 - seveal args? - L375: missinig assert? 
+//Q2 - seveal args? - L375: missinig assert?
 
 var got = _.path.isGlobal( '//', '://' );
 console.log( 'Result', got );

--- a/sample/SampleIs.js
+++ b/sample/SampleIs.js
@@ -4,5 +4,17 @@ require( 'wPathFundamentals' );
 require( 'wFiles' )
 var _ = wTools;
 
-var got = _.path.isSafe( 'c:/Windows/f/', 3 );
+var got = _.path.isAbsolute( '/c:/Windows/f');
+console.log( 'Result', got );
+var got = _.path.isAbsolute( 'c:/Windows/f/g');
+console.log( 'Result', got );
+var got = _.path.isAbsolute( 'C:/Windows/f');
+console.log( 'Result', got );
+var got = _.path.isAbsolute( '/C/Windows/f');
+console.log( 'Result', got );
+
+var got = _.path.normalize( '/C:/temp/foo/bar/../');
+console.log( 'Result', got );
+
+var got = _.path.isNormalized( 'c://temp/foo/bar/');
 console.log( 'Result', got );

--- a/sample/SampleIs.js
+++ b/sample/SampleIs.js
@@ -1,0 +1,8 @@
+
+if( typeof module !== 'undefined' )
+require( 'wPathFundamentals' );
+require( 'wFiles' )
+var _ = wTools;
+
+  var got = _.path.isSafe( 'c/ProgramFiles/f/g', 3 );
+console.log( 'Result', got );

--- a/sample/SampleIs.js
+++ b/sample/SampleIs.js
@@ -6,6 +6,7 @@ var _ = wTools;
 
 
 //Q1 - L358: should use instead isNormalized in assert?
+logger.log( 'Q1 - normalized path');
 
 var got = _.path.isAbsolute( 'c:/Windows/f/g');
 console.log( 'Result', got );
@@ -16,11 +17,13 @@ console.log( 'Result', got );
 var got = _.path.isAbsolute( got );
 console.log( 'Result', got );
 
+logger.log( '' );
+
 //Q2 - isGlobal, isDotted, isTrailed, begins, ends don´t have several args assert
+logger.log( 'Q2 - Several arguments');
 
 var got = _.path.isGlobal( '//', '://' );
 console.log( 'Result', got );
-
 
 var got = _.path.isDotted( '//', '.' );
 console.log( 'Result', got );
@@ -28,8 +31,13 @@ console.log( 'Result', got );
 var got = _.path.isTrailed( '//.', './' );
 console.log( 'Result', got );
 
-
 var got = _.path.begins( 'a/b', 'a', 'c' );
 console.log( 'Result', got );
 
+var got = _.path.ends( 'a/b', 'a', 'c' );
+console.log( 'Result', got );
+
+logger.log( '' );
+
 //Q3 - begins L2179 test file
+logger.log( 'Q3 - Wrong input arguments');

--- a/sample/SampleIs.js
+++ b/sample/SampleIs.js
@@ -4,5 +4,5 @@ require( 'wPathFundamentals' );
 require( 'wFiles' )
 var _ = wTools;
 
-  var got = _.path.isSafe( 'c/ProgramFiles/f/g', 3 );
+var got = _.path.isSafe( 'c:/Windows/f/', 3 );
 console.log( 'Result', got );

--- a/sample/SampleIs.js
+++ b/sample/SampleIs.js
@@ -20,3 +20,8 @@ console.log( 'Result', got );
 
 var got = _.path.isGlobal( '//', '://' );
 console.log( 'Result', got );
+
+//Q3 - isDotted and isTrailed don´t have asserts - several args?
+
+var got = _.path.isDotted( '//', '.' );
+console.log( 'Result', got );

--- a/sample/SampleIs.js
+++ b/sample/SampleIs.js
@@ -5,7 +5,7 @@ require( 'wFiles' )
 var _ = wTools;
 
 
-//Q1 - L358
+//Q1 - L358: should use instead isNormalized in assert?
 
 var got = _.path.isAbsolute( 'c:/Windows/f/g');
 console.log( 'Result', got );
@@ -14,4 +14,9 @@ var got = _.path.normalize( 'c:/Windows/f/g');
 console.log( 'Result', got );
 
 var got = _.path.isAbsolute( got );
+console.log( 'Result', got );
+
+//Q2 - seveal args? - L375: missinig assert? 
+
+var got = _.path.isGlobal( '//', '://' );
 console.log( 'Result', got );

--- a/sample/SampleIs.js
+++ b/sample/SampleIs.js
@@ -16,12 +16,20 @@ console.log( 'Result', got );
 var got = _.path.isAbsolute( got );
 console.log( 'Result', got );
 
-//Q2 - seveal args? - L375: missinig assert?
+//Q2 - isGlobal, isDotted, isTrailed, begins, ends don´t have several args assert
 
 var got = _.path.isGlobal( '//', '://' );
 console.log( 'Result', got );
 
-//Q3 - isDotted and isTrailed don´t have asserts - several args?
 
 var got = _.path.isDotted( '//', '.' );
 console.log( 'Result', got );
+
+var got = _.path.isTrailed( '//.', './' );
+console.log( 'Result', got );
+
+
+var got = _.path.begins( 'a/b', 'a', 'c' );
+console.log( 'Result', got );
+
+//Q3 - begins L2179 test file

--- a/sample/SampleIs.js
+++ b/sample/SampleIs.js
@@ -4,17 +4,14 @@ require( 'wPathFundamentals' );
 require( 'wFiles' )
 var _ = wTools;
 
-var got = _.path.isAbsolute( '/c:/Windows/f');
-console.log( 'Result', got );
+
+//Q1 - L358
+
 var got = _.path.isAbsolute( 'c:/Windows/f/g');
 console.log( 'Result', got );
-var got = _.path.isAbsolute( 'C:/Windows/f');
-console.log( 'Result', got );
-var got = _.path.isAbsolute( '/C/Windows/f');
+
+var got = _.path.normalize( 'c:/Windows/f/g');
 console.log( 'Result', got );
 
-var got = _.path.normalize( '/C:/temp/foo/bar/../');
-console.log( 'Result', got );
-
-var got = _.path.isNormalized( 'c://temp/foo/bar/');
+var got = _.path.isAbsolute( got );
 console.log( 'Result', got );

--- a/sample/SampleIs.js
+++ b/sample/SampleIs.js
@@ -5,10 +5,10 @@ require( 'wFiles' )
 var _ = wTools;
 
 
-//Q1 - L358: should use instead isNormalized in assert?
+//Q1 - L358: should use instead isNormalized in assert? - The change throws many errors
 logger.log( 'Q1 - normalized path');
 
-var got = _.path.isAbsolute( 'c:/Windows/f/g');
+var got = _.path.isAbsolute( 'c:/Windows/f/g' );
 console.log( 'Result', got );
 
 var got = _.path.normalize( 'c:/Windows/f/g');
@@ -16,28 +16,3 @@ console.log( 'Result', got );
 
 var got = _.path.isAbsolute( got );
 console.log( 'Result', got );
-
-logger.log( '' );
-
-//Q2 - isGlobal, isDotted, isTrailed, begins, ends don´t have several args assert
-logger.log( 'Q2 - Several arguments');
-
-var got = _.path.isGlobal( '//', '://' );
-console.log( 'Result', got );
-
-var got = _.path.isDotted( '//', '.' );
-console.log( 'Result', got );
-
-var got = _.path.isTrailed( '//.', './' );
-console.log( 'Result', got );
-
-var got = _.path.begins( 'a/b', 'a', 'c' );
-console.log( 'Result', got );
-
-var got = _.path.ends( 'a/b', 'a', 'c' );
-console.log( 'Result', got );
-
-logger.log( '' );
-
-//Q3 - begins L2179 test file
-logger.log( 'Q3 - Wrong input arguments');


### PR DESCRIPTION
- Re-order Path.test.s test routines according to Path.s routines order
- Re-order Glob.test.s test routines according to Glob.s routines order

Test routines for:
- is
- are
- like
- isSafe
- isNormalized
- isRefined
- isAbsolute
- isRelative
- isGlobal
- isRoot
- isDotted
- isTrailed
- begins
- ends